### PR TITLE
Allow for optional explicit variable declarations

### DIFF
--- a/Alto/CodeAnalysis/Binding/Binder.cs
+++ b/Alto/CodeAnalysis/Binding/Binder.cs
@@ -242,7 +242,7 @@ namespace Alto.CodeAnalysis.Binding
 
             if (conversion.IsExplicit && !allowExplicit)
             {
-                _diagnostics.ReportCannotConvertImplicitly(span, expression.Type, type);
+                _diagnostics.ReportCannotImplicitlyConvert(span, expression.Type, type);
                 return new BoundErrorExpression();
             }
 

--- a/Alto/CodeAnalysis/Binding/Binder.cs
+++ b/Alto/CodeAnalysis/Binding/Binder.cs
@@ -94,10 +94,26 @@ namespace Alto.CodeAnalysis.Binding
         private BoundStatement BindVariableDeclaration(VariableDeclarationSyntax syntax)
         {
             var isReadOnly = syntax.Keyword.Kind == SyntaxKind.LetKeyword;
+            var type = BindTypeClause(syntax.TypeClause);
             var initializer = BindExpression(syntax.Initializer);
-            var variable = BindVariable(syntax.Identifier, isReadOnly, initializer.Type);
+            var variableType = type ?? initializer.Type;
+            var castedInitializer = BindConversion(initializer, variableType, syntax.Initializer.Span);
+            var variable = BindVariable(syntax.Identifier, isReadOnly, variableType);
 
-            return new BoundVariableDeclaration(variable, initializer);
+            return new BoundVariableDeclaration(variable, castedInitializer);
+        }
+
+        private TypeSymbol BindTypeClause(TypeClauseSyntax syntax)
+        {
+            if (syntax == null)
+                return null;
+            
+            var type = LookupType(syntax.Identifier.Text);
+            
+            if (type == null)
+                _diagnostics.ReportUndefinedType(syntax.Identifier.Span, syntax.Identifier.Text);
+
+            return type;
         }
 
         private BoundStatement BindIfStatement(IfStatementSyntax syntax)
@@ -202,15 +218,15 @@ namespace Alto.CodeAnalysis.Binding
             }
         }
 
-        private BoundExpression BindConversion(ExpressionSyntax syntax, TypeSymbol type)
+        private BoundExpression BindConversion(ExpressionSyntax syntax, TypeSymbol type, bool allowExplicit = false)
         {
             var expression = BindExpression(syntax);
             var span = syntax.Span;
 
-            return BindConversion(expression, type, span);
+            return BindConversion(expression, type, span, allowExplicit);
         }
 
-        private BoundExpression BindConversion(BoundExpression expression, TypeSymbol type, TextSpan span)
+        private BoundExpression BindConversion(BoundExpression expression, TypeSymbol type, TextSpan span, bool allowExplicit = false)
         {
             var conversion = Conversion.Classify(expression.Type, type);
 
@@ -221,6 +237,12 @@ namespace Alto.CodeAnalysis.Binding
                     _diagnostics.ReportCannotConvert(span, expression.Type, type);
                 }
 
+                return new BoundErrorExpression();
+            }
+
+            if (conversion.IsExplicit && !allowExplicit)
+            {
+                _diagnostics.ReportCannotConvertImplicitly(span, expression.Type, type);
                 return new BoundErrorExpression();
             }
 
@@ -309,7 +331,7 @@ namespace Alto.CodeAnalysis.Binding
         private BoundExpression BindCallExpression(CallExpressionSyntax syntax)
         {
             if (syntax.Arguments.Count == 1 && LookupTypeConversion(syntax.Identifier.Text) is TypeSymbol type)
-                return BindConversion(syntax.Arguments[0], type);
+                return BindConversion(syntax.Arguments[0], type, allowExplicit: true);
 
             var boundArguments = ImmutableArray.CreateBuilder<BoundExpression>();
 

--- a/Alto/CodeAnalysis/Binding/Binder.cs
+++ b/Alto/CodeAnalysis/Binding/Binder.cs
@@ -338,7 +338,7 @@ namespace Alto.CodeAnalysis.Binding
             var variable = new VariableSymbol(name, isReadOnly, type);
 
             if (declare && !_scope.TryDeclareVariable(variable))
-                _diagnostics.ReportVariableAlreadyDeclared(identifier.Span, name);
+                _diagnostics.ReportSymbolAlreadyDeclared(identifier.Span, name);
             
             return variable;
         }

--- a/Alto/CodeAnalysis/DiagnosticBag.cs
+++ b/Alto/CodeAnalysis/DiagnosticBag.cs
@@ -79,15 +79,21 @@ namespace Alto.CodeAnalysis
             Report(span, message);
         }
 
-        public void ReportCannotAssign(TextSpan span, string name)
+        public void ReportCannotConvert(TextSpan span, TypeSymbol fromType, TypeSymbol targetType)
         {
-            var message = $"Cannot assign to variable '{name}'.";
+            var message = $"Cannot convert type '{fromType.ToString()}' to type '{targetType.ToString()}'.";
             Report(span, message);
         }
 
-        public void ReportCannotConvert(TextSpan span, TypeSymbol type, TypeSymbol targetType)
+        internal void ReportCannotImplicitlyConvert(TextSpan span, TypeSymbol fromType, TypeSymbol targetType)
         {
-            var message = $"Cannot convert type '{type.ToString()}' to type '{targetType.ToString()}'.";
+            var message = $"Cannot implicitly convert type '{fromType.ToString()}' to type '{targetType.ToString()}'. An explicit conversion exists, are you missing a cast?";
+            Report(span, message);
+        }
+
+        public void ReportCannotAssign(TextSpan span, string name)
+        {
+            var message = $"Cannot assign to variable '{name}'.";
             Report(span, message);
         }
 
@@ -115,10 +121,17 @@ namespace Alto.CodeAnalysis
             Report(span, message);
         }
 
-        internal void ReportExpressionMustHaveAValue(TextSpan span)
+        public void ReportUndefinedType(TextSpan span, string type)
+        {
+            var message = $"Type '{type} is not defined in the current scope.'";
+            Report(span, message);
+        }
+
+        public void ReportExpressionMustHaveAValue(TextSpan span)
         {
             var message = $"Expression must have a different value than void.";
             Report(span, message);
         }
+
     }
 }

--- a/Alto/CodeAnalysis/DiagnosticBag.cs
+++ b/Alto/CodeAnalysis/DiagnosticBag.cs
@@ -67,9 +67,9 @@ namespace Alto.CodeAnalysis
             Report(span, message);
         }
 
-        public void ReportVariableAlreadyDeclared(TextSpan span, string name)
+        public void ReportSymbolAlreadyDeclared(TextSpan span, string name)
         {
-            var message = $"Variable '{name}' is already declared in the current scope.";
+            var message = $"'{name}' is already declared in the current scope.";
             Report(span, message);
         }
 

--- a/Alto/CodeAnalysis/Syntax/Lexer.cs
+++ b/Alto/CodeAnalysis/Syntax/Lexer.cs
@@ -164,6 +164,7 @@ namespace Alto.CodeAnalysis.Syntax
                     }
                     break;
                 case ':':
+                    _position++;
                     _kind = SyntaxKind.ColonToken;
                     break;
                 case ',':

--- a/Alto/CodeAnalysis/Syntax/Lexer.cs
+++ b/Alto/CodeAnalysis/Syntax/Lexer.cs
@@ -163,6 +163,9 @@ namespace Alto.CodeAnalysis.Syntax
                         _kind = SyntaxKind.GreaterOrEqualsToken;
                     }
                     break;
+                case ':':
+                    _kind = SyntaxKind.ColonToken;
+                    break;
                 case ',':
                     _position++;
                     _kind = SyntaxKind.CommaToken;

--- a/Alto/CodeAnalysis/Syntax/Parser.cs
+++ b/Alto/CodeAnalysis/Syntax/Parser.cs
@@ -95,10 +95,27 @@ namespace Alto.CodeAnalysis.Syntax
             var expected = Current.Kind == SyntaxKind.LetKeyword ? SyntaxKind.LetKeyword : SyntaxKind.VarKeyword;
             var keyword = MatchToken(expected);
             var identifier = MatchToken(SyntaxKind.IdentifierToken);
+            var typeClause = ParseOptionalTypeClause();
             var equals = MatchToken(SyntaxKind.EqualsToken);
             var initializer = ParseExpression();
 
-            return new VariableDeclarationSyntax(keyword, identifier, equals, initializer);
+            return new VariableDeclarationSyntax(keyword, identifier, typeClause, equals, initializer);
+        }
+
+        private TypeClauseSyntax ParseOptionalTypeClause()
+        {
+            if (Current.Kind != SyntaxKind.ColonToken)
+                return null;
+
+            return ParseTypeClause();
+        }
+
+        private TypeClauseSyntax ParseTypeClause()
+        {
+            var colonToken = MatchToken(SyntaxKind.ColonToken);
+            var identifier = MatchToken(SyntaxKind.IdentifierToken);
+
+            return new TypeClauseSyntax(colonToken, identifier);
         }
 
         private StatementSyntax ParseIfStatement()

--- a/Alto/CodeAnalysis/Syntax/SyntaxFacts.cs
+++ b/Alto/CodeAnalysis/Syntax/SyntaxFacts.cs
@@ -156,6 +156,8 @@ namespace Alto.CodeAnalysis.Syntax
                     return "to";
                 case SyntaxKind.CommaToken:
                     return ",";
+                case SyntaxKind.ColonToken:
+                    return ":";
                 default:
                     return null;
             }

--- a/Alto/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/Alto/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -54,6 +54,7 @@ namespace Alto.CodeAnalysis.Syntax
         //Nodes
         CompilationUnit,
         ElseClause,
+        TypeClause,
 
         //Expression Tokens     
         LiteralExpression,
@@ -71,6 +72,6 @@ namespace Alto.CodeAnalysis.Syntax
         IfStatement,
         WhileStatement,
         ForStatement,
-        DoWhileStatement,
+        DoWhileStatement
     }
 }

--- a/Alto/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/Alto/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -37,6 +37,7 @@ namespace Alto.CodeAnalysis.Syntax
         PipeToken,
         HatToken,
         CommaToken,
+        ColonToken,
 
         //Keywords
         FalseKeyword,

--- a/Alto/CodeAnalysis/Syntax/TypeClauseSyntax.cs
+++ b/Alto/CodeAnalysis/Syntax/TypeClauseSyntax.cs
@@ -1,0 +1,16 @@
+namespace Alto.CodeAnalysis.Syntax
+{
+    public sealed class TypeClauseSyntax : SyntaxNode
+    {
+        public TypeClauseSyntax(SyntaxToken colonToken, SyntaxToken identifier)
+        {
+            ColonToken = colonToken;
+            Identifier = identifier;
+        }
+
+        public SyntaxToken ColonToken { get; }
+        public SyntaxToken Identifier { get; }
+
+        public override SyntaxKind Kind => SyntaxKind.TypeClause;
+    }
+}

--- a/Alto/CodeAnalysis/Syntax/VariableDeclarationSyntax.cs
+++ b/Alto/CodeAnalysis/Syntax/VariableDeclarationSyntax.cs
@@ -2,10 +2,11 @@ namespace Alto.CodeAnalysis.Syntax
 {
     public sealed class VariableDeclarationSyntax : StatementSyntax
     {
-        public VariableDeclarationSyntax(SyntaxToken keyword, SyntaxToken identifier, SyntaxToken equalsToken, ExpressionSyntax initializer)
+        public VariableDeclarationSyntax(SyntaxToken keyword, SyntaxToken identifier, TypeClauseSyntax typeClause, SyntaxToken equalsToken, ExpressionSyntax initializer)
         {
             Keyword = keyword;
             Identifier = identifier;
+            TypeClause = typeClause;
             EqualsToken = equalsToken;
             Initializer = initializer;
         }
@@ -13,6 +14,7 @@ namespace Alto.CodeAnalysis.Syntax
 
         public SyntaxToken Keyword { get; }
         public SyntaxToken Identifier { get; }
+        public TypeClauseSyntax TypeClause { get; }
         public SyntaxToken EqualsToken { get; }
         public ExpressionSyntax Initializer { get; }
     }


### PR DESCRIPTION
## Usage
This new API should be used to create explicit variable declarations. Eg. you can declare a strongly typed variable that of say, `int`. Then, when you try to set its value to a string, it'll result in an error being thrown.

## Syntax
I went with a "typescript style" syntax where the type is defined after the identifier. This easily changed in the parser later on.
```
{
    var x : int = 99
}
```