### PR TITLE
Subroutine declarations!

### DIFF
--- a/Alto.Tests/CodeAnalysis/EvaluatorTests.cs
+++ b/Alto.Tests/CodeAnalysis/EvaluatorTests.cs
@@ -140,18 +140,6 @@ namespace Alto.Tests.CodeAnalysis
         }
 
         [Fact]
-        public void Evaluator_NameExpression_Reports_NoErrorForInsertedToken()
-        {
-            var text = @"[]";
-
-            var diagnostics = @"
-                Unexpeced token <EndOfFileToken>, expected <IdentifierToken>.
-            ";
-
-            AssertDiagnostics(text, diagnostics);
-        }
-
-        [Fact]
         public void Evaluator_AssignedExpression_Reports_CannotAssign()
         {
             var text = @"

--- a/Alto.Tests/CodeAnalysis/Syntax/ParserTests.cs
+++ b/Alto.Tests/CodeAnalysis/Syntax/ParserTests.cs
@@ -102,8 +102,9 @@ namespace Alto.Tests.CodeAnalysis.Syntax
         {
             var syntaxTree = SyntaxTree.Parse(text);
             var root = syntaxTree.Root;
-            var statement = root.Statement;
-            return Assert.IsType<ExpressionStatementSyntax>(statement).Expression;
+            var member = Assert.Single(root.Members);
+            var globalStatement = Assert.IsType<GlobalStatementSyntax>(member);
+            return Assert.IsType<ExpressionStatementSyntax>(globalStatement.Statement).Expression;
         }
 
         public static IEnumerable<object[]> GetUnaryOperatorPairsData()

--- a/Alto/CodeAnalysis/Binding/BoundGlobalScope.cs
+++ b/Alto/CodeAnalysis/Binding/BoundGlobalScope.cs
@@ -5,16 +5,20 @@ namespace Alto.CodeAnalysis.Binding
 {
     internal sealed class BoundGlobalScope
     {
-        public BoundGlobalScope(BoundGlobalScope previous, ImmutableArray<Diagnostic> diagnostics, ImmutableArray<VariableSymbol> variables, BoundStatement statement)
+        public BoundGlobalScope(BoundGlobalScope previous, ImmutableArray<Diagnostic> diagnostics, 
+            ImmutableArray<FunctionSymbol> functions, ImmutableArray<VariableSymbol> variables, 
+            BoundStatement statement)
         {
             Previous = previous;
             Diagnostics = diagnostics;
+            Functions = functions;
             Variables = variables;
             Statement = statement;
         }
 
         public BoundGlobalScope Previous { get; }
         public ImmutableArray<Diagnostic> Diagnostics { get; }
+        public ImmutableArray<FunctionSymbol> Functions { get; }
         public ImmutableArray<VariableSymbol> Variables { get; }
         public BoundStatement Statement { get; }
     }

--- a/Alto/CodeAnalysis/Binding/BoundProgram.cs
+++ b/Alto/CodeAnalysis/Binding/BoundProgram.cs
@@ -1,0 +1,19 @@
+using System.Collections.Immutable;
+using Alto.CodeAnalysis.Symbols;
+
+namespace Alto.CodeAnalysis.Binding
+{
+    internal class BoundProgram
+    {
+        public BoundProgram(BoundGlobalScope globalScope, DiagnosticBag diagnostics, ImmutableDictionary<FunctionSymbol, BoundBlockStatement> functionBodies)
+        {
+            GlobalScope = globalScope;
+            Diagnostics = diagnostics;
+            FunctionBodies = functionBodies;
+        }
+
+        public BoundGlobalScope GlobalScope { get; }
+        public DiagnosticBag Diagnostics { get; }
+        public ImmutableDictionary<FunctionSymbol, BoundBlockStatement> FunctionBodies { get; }
+    }
+}

--- a/Alto/CodeAnalysis/Compilation.cs
+++ b/Alto/CodeAnalysis/Compilation.cs
@@ -57,8 +57,12 @@ namespace Alto.CodeAnalysis
             if (diagnostics.Any())
                 return new EvaluationResult(diagnostics, null);
 
+            var program = Binder.BindProgram(GlobalScope);
+            if (program.Diagnostics.Any())
+                return new EvaluationResult(program.Diagnostics.ToImmutableArray(), null);
+
             var statement = GetStatement();
-            var evaluator = new Evaluator(statement, variables);
+            var evaluator = new Evaluator(program.FunctionBodies, statement, variables);
             var value = evaluator.Evaluate();
 
             return new EvaluationResult(ImmutableArray<Diagnostic>.Empty, value);

--- a/Alto/CodeAnalysis/DiagnosticBag.cs
+++ b/Alto/CodeAnalysis/DiagnosticBag.cs
@@ -67,6 +67,12 @@ namespace Alto.CodeAnalysis
             Report(span, message);
         }
 
+        internal void ReportParameterAlreadyDeclared(string name, TextSpan span)
+        {
+            var message = $"A parameter with name '{name}' is already defined.";
+            Report(span, message);
+        }
+
         public void ReportSymbolAlreadyDeclared(TextSpan span, string name)
         {
             var message = $"'{name}' is already declared in the current scope.";
@@ -117,7 +123,7 @@ namespace Alto.CodeAnalysis
 
         public void ReportWrongArgumentType(TextSpan span, string funcName, string paramName, TypeSymbol paramType, TypeSymbol argumentType)
         {
-            var message = $"Parameter '{paramName}' in '{funcName}' has to be of type '{paramType.ToString()} is of type '{argumentType.ToString()}'.";
+            var message = $"Parameter '{paramName}' in '{funcName}' has to be of type '{paramType}' is of type '{argumentType}'.";
             Report(span, message);
         }
 
@@ -133,5 +139,10 @@ namespace Alto.CodeAnalysis
             Report(span, message);
         }
 
+        internal void TEMPORARY_ReportFunctionsAreUnsupported(TextSpan span)
+        {
+            var message = "Functions with returns are not supported yet.";
+            Report(span, message);
+        }
     }
 }

--- a/Alto/CodeAnalysis/Evaluator.cs
+++ b/Alto/CodeAnalysis/Evaluator.cs
@@ -21,6 +21,8 @@ namespace Alto.CodeAnalysis
             _functionBodies = functionBodies;
             _root = root;
             _globals = variables;
+            
+            _locals.Push(new Dictionary<VariableSymbol, object>());
         }
         public object Evaluate()
         {
@@ -41,7 +43,7 @@ namespace Alto.CodeAnalysis
             while (index < body.Statements.Length)
             {
                 var s = body.Statements[index];
-
+                
                 switch (s.Kind)
                 {
                     case BoundNodeKind.VariableDeclaration:

--- a/Alto/CodeAnalysis/Evaluator.cs
+++ b/Alto/CodeAnalysis/Evaluator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Alto.CodeAnalysis.Binding;
 using Alto.CodeAnalysis.Symbols;
 
@@ -7,29 +8,39 @@ namespace Alto.CodeAnalysis
 {
     internal sealed class Evaluator
     {
-        private readonly Dictionary<VariableSymbol, object> _variables;
+        private readonly ImmutableDictionary<FunctionSymbol, BoundBlockStatement> _functionBodies;
+        private readonly Dictionary<VariableSymbol, object> _globals;
+        private readonly Stack<Dictionary<VariableSymbol, object>> _locals = new Stack<Dictionary<VariableSymbol, object>>();
         public BoundBlockStatement _root { get; }
         private Random _random;
 
         private object _lastValue;
 
-        public Evaluator(BoundBlockStatement root, Dictionary<VariableSymbol, object> variables)
+        public Evaluator(ImmutableDictionary<FunctionSymbol, BoundBlockStatement> functionBodies, BoundBlockStatement root, Dictionary<VariableSymbol, object> variables)
         {
+            _functionBodies = functionBodies;
             _root = root;
-            _variables = variables;
+            _globals = variables;
         }
         public object Evaluate()
         {
+            var body = _root;
+
+            return EvaluateStatement(body);
+        }
+
+        private object EvaluateStatement(BoundBlockStatement body)
+        {
             var labelToIndex = new Dictionary<BoundLabel, int>();
 
-            for (var i = 0; i < _root.Statements.Length; i++)
-                if (_root.Statements[i] is BoundLabelStatement l)
-                    labelToIndex.Add(l.Label, i + 1);    
+            for (var i = 0; i < body.Statements.Length; i++)
+                if (body.Statements[i] is BoundLabelStatement l)
+                    labelToIndex.Add(l.Label, i + 1);
 
             var index = 0;
-            while (index < _root.Statements.Length)
+            while (index < body.Statements.Length)
             {
-                var s = _root.Statements[index];
+                var s = body.Statements[index];
 
                 switch (s.Kind)
                 {
@@ -59,16 +70,16 @@ namespace Alto.CodeAnalysis
                     default:
                         throw new Exception($"Unexpected node {s.Kind}");
                 }
-            }   
+            }
             return _lastValue;
         }
-        
+
         private void EvaluateVariableDeclaration(BoundVariableDeclaration node)
         {
             var value = EvaluateExpression(node.Initializer);
-            _variables[node.Variable] = value;
             _lastValue = value;
-        }   
+            Assign(node.Variable, value);
+        }
 
         private void EvaluateExpressionStatement(BoundExpressionStatement node)
         {
@@ -177,7 +188,8 @@ namespace Alto.CodeAnalysis
         private object EvaluateAssignmentExpression(BoundAssignmentExpression a)
         {
             var value = EvaluateExpression(a.Expression);
-            _variables[a.Variable] = value;
+            Assign(a.Variable, value);
+
             return value;
         }
 
@@ -185,11 +197,19 @@ namespace Alto.CodeAnalysis
         {
             return n.Value;
         }
-
+        
         private object EvaluateVariableExpression(BoundVariableExpression v)
         {
-            var value = _variables[v.Variable];
-            return value;
+            if (v.Variable.Kind == SymbolKind.GlobalVariable)
+            {
+                var global = _globals[v.Variable];
+                return global;
+            }
+            else
+            {
+                var locals = _locals.Peek();
+                return locals[v.Variable];
+            }
         }
 
         private object EvaluateCallExpression(BoundCallExpression node)
@@ -216,7 +236,22 @@ namespace Alto.CodeAnalysis
             }
             else
             {
-                throw new Exception($"Unexpected function {node.Function.Name}");
+                var locals = new Dictionary<VariableSymbol, object>();
+
+                for (var i = 0; i < node.Arguments.Length; i++)
+                {
+                    var parameter = node.Function.Parameters[i];
+                    var value = EvaluateExpression(node.Arguments[i]);
+                    locals.Add(parameter, value);
+                }
+
+                _locals.Push(locals); 
+
+                var statement = _functionBodies[node.Function];
+                var result = EvaluateStatement(statement);
+                
+                _locals.Pop();
+                return result;         
             }
         }
 
@@ -232,6 +267,19 @@ namespace Alto.CodeAnalysis
                 return Convert.ToString(value);
             else
                 throw new Exception($"Unexpected type {node.Type}");
+        }
+
+        private void Assign(VariableSymbol variable, object value)
+        {
+            if (variable.Kind == SymbolKind.GlobalVariable)
+            {
+                _globals[variable] = value;
+            }
+            else
+            {
+                var locals = _locals.Peek();
+                locals[variable] = value;
+            }
         }
     }
 }

--- a/Alto/CodeAnalysis/Lowering/Lowerer.cs
+++ b/Alto/CodeAnalysis/Lowering/Lowerer.cs
@@ -199,7 +199,7 @@ namespace Alto.CodeAnalysis.Lowering
             
             var variableDeclaration = new BoundVariableDeclaration(node.Variable, node.LowerBound);
             var variableExpression = new BoundVariableExpression(node.Variable);
-            var upperBoundSymbol = new VariableSymbol("upperBound", true, TypeSymbol.Int);
+            var upperBoundSymbol = new LocalVariableSymbol("upperBound", true, TypeSymbol.Int);
             var upperBoundDeclaration = new BoundVariableDeclaration(upperBoundSymbol, node.UpperBound);
             var condition = new BoundBinaryExpression(
                 variableExpression,

--- a/Alto/CodeAnalysis/Symbols/FunctionSymbol.cs
+++ b/Alto/CodeAnalysis/Symbols/FunctionSymbol.cs
@@ -1,19 +1,22 @@
 using System.Collections.Immutable;
+using Alto.CodeAnalysis.Syntax;
 
 namespace Alto.CodeAnalysis.Symbols
 {
     public sealed class FunctionSymbol : Symbol
     {
-        public FunctionSymbol(string name, ImmutableArray<ParameterSymbol> parameters, TypeSymbol type)
+        public FunctionSymbol(string name, ImmutableArray<ParameterSymbol> parameters, TypeSymbol type, FunctionDeclarationSyntax declaration = null)
             : base(name)
         {
             Parameters = parameters;
             Type = type;
+            Declaration = declaration;
         }
 
         public override SymbolKind Kind => SymbolKind.Function;
         public ImmutableArray<ParameterSymbol> Parameters { get; }
         public TypeSymbol Type { get; }
+        public FunctionDeclarationSyntax Declaration { get; }
 
         public override string ToString() => Name;
     }

--- a/Alto/CodeAnalysis/Symbols/GlobalVariableSymbol.cs
+++ b/Alto/CodeAnalysis/Symbols/GlobalVariableSymbol.cs
@@ -1,0 +1,13 @@
+namespace Alto.CodeAnalysis.Symbols
+{
+    public class GlobalVariableSymbol : VariableSymbol
+    {
+        internal GlobalVariableSymbol(string name, bool isReadOnly, TypeSymbol type)
+            : base(name, isReadOnly, type)
+        {
+        }
+
+        public override SymbolKind Kind => SymbolKind.GlobalVariable;
+        public override string ToString() => Name;
+    }
+}

--- a/Alto/CodeAnalysis/Symbols/LocalVariableSymbol.cs
+++ b/Alto/CodeAnalysis/Symbols/LocalVariableSymbol.cs
@@ -1,0 +1,13 @@
+namespace Alto.CodeAnalysis.Symbols
+{
+    public class LocalVariableSymbol : VariableSymbol
+    {
+        internal LocalVariableSymbol(string name, bool isReadOnly, TypeSymbol type)
+            : base(name, isReadOnly, type)
+        {
+        }
+
+        public override SymbolKind Kind => SymbolKind.LocalVariable;
+        public override string ToString() => Name;
+    }
+}

--- a/Alto/CodeAnalysis/Symbols/ParameterSymbol.cs
+++ b/Alto/CodeAnalysis/Symbols/ParameterSymbol.cs
@@ -1,6 +1,6 @@
 namespace Alto.CodeAnalysis.Symbols
 {
-    public sealed class ParameterSymbol : VariableSymbol
+    public sealed class ParameterSymbol : LocalVariableSymbol
     {
         public ParameterSymbol(string name, TypeSymbol type)
             : base(name: name, isReadOnly: true, type: type)

--- a/Alto/CodeAnalysis/Symbols/SymbolKind.cs
+++ b/Alto/CodeAnalysis/Symbols/SymbolKind.cs
@@ -3,8 +3,9 @@ namespace Alto.CodeAnalysis.Symbols
     public enum SymbolKind
     {
         Variable,
+        GlobalVariable,
+        LocalVariable,
         Type,
-        
         Function,
         Parameter
     }

--- a/Alto/CodeAnalysis/Symbols/VariableSymbol.cs
+++ b/Alto/CodeAnalysis/Symbols/VariableSymbol.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Alto.CodeAnalysis.Symbols
 {
-    public class VariableSymbol : Symbol
+    public abstract class VariableSymbol : Symbol
     {
         internal VariableSymbol(string name, bool isReadOnly, TypeSymbol type)
             : base(name)
@@ -13,8 +13,6 @@ namespace Alto.CodeAnalysis.Symbols
 
         public bool IsReadOnly { get; }
         public TypeSymbol Type { get; }
-
-        public override SymbolKind Kind => SymbolKind.Variable;
         public override string ToString() => Name;
     }
 }

--- a/Alto/CodeAnalysis/Syntax/CompilationUnitSyntax.cs
+++ b/Alto/CodeAnalysis/Syntax/CompilationUnitSyntax.cs
@@ -1,14 +1,16 @@
+using System.Collections.Immutable;
+
 namespace Alto.CodeAnalysis.Syntax
 {
     public sealed class CompilationUnitSyntax : SyntaxNode
     {
-        public CompilationUnitSyntax(StatementSyntax statement, SyntaxToken endOfFileToken)
+        public CompilationUnitSyntax(ImmutableArray<MemberSyntax> members, SyntaxToken endOfFileToken)
         {
-            Statement = statement;
+            Members = members;
             EndOfFileToken = endOfFileToken;
         }
 
-        public StatementSyntax Statement { get; }
+        public ImmutableArray<MemberSyntax> Members { get; }
         public SyntaxToken EndOfFileToken { get; }
         public override SyntaxKind Kind => SyntaxKind.CompilationUnit;
     }

--- a/Alto/CodeAnalysis/Syntax/FunctionDeclarationSyntax.cs
+++ b/Alto/CodeAnalysis/Syntax/FunctionDeclarationSyntax.cs
@@ -1,0 +1,28 @@
+namespace Alto.CodeAnalysis.Syntax
+{
+    public sealed class FunctionDeclarationSyntax : MemberSyntax
+    {
+        public FunctionDeclarationSyntax(SyntaxToken functionKeyword, SyntaxToken identifier, 
+            SyntaxToken openParenthesisToken, SeparatedSyntaxList<ParameterSyntax> parameters, SyntaxToken closedParenthesisToken,
+            TypeClauseSyntax type, BlockStatementSyntax body)
+        {
+            FunctionKeyword = functionKeyword;
+            Identifier = identifier;
+            OpenParenthesisToken = openParenthesisToken;
+            Parameters = parameters;
+            ClosedParenthesisToken = closedParenthesisToken;
+            Type = type;
+            Body = body;
+        }
+
+        public SyntaxToken FunctionKeyword { get; }
+        public SyntaxToken Identifier { get; }
+        public SyntaxToken OpenParenthesisToken { get; }
+        public SeparatedSyntaxList<ParameterSyntax> Parameters { get; }
+        public SyntaxToken ClosedParenthesisToken { get; }
+        public TypeClauseSyntax Type { get; }
+        public BlockStatementSyntax Body { get; }
+
+        public override SyntaxKind Kind => SyntaxKind.FunctionDeclaration;
+    }
+}

--- a/Alto/CodeAnalysis/Syntax/GlobalStatementSyntax.cs
+++ b/Alto/CodeAnalysis/Syntax/GlobalStatementSyntax.cs
@@ -1,0 +1,13 @@
+namespace Alto.CodeAnalysis.Syntax
+{
+    public sealed class GlobalStatementSyntax : MemberSyntax
+    {
+        public GlobalStatementSyntax(StatementSyntax statement)
+        {
+            Statement = statement;
+        }
+
+        public StatementSyntax Statement { get; }
+        public override SyntaxKind Kind => SyntaxKind.GlobalStatement;
+    }
+}

--- a/Alto/CodeAnalysis/Syntax/MemberSyntax.cs
+++ b/Alto/CodeAnalysis/Syntax/MemberSyntax.cs
@@ -1,0 +1,6 @@
+namespace Alto.CodeAnalysis.Syntax
+{
+    public abstract class MemberSyntax : SyntaxNode
+    {
+    }
+}

--- a/Alto/CodeAnalysis/Syntax/ParameterSyntax.cs
+++ b/Alto/CodeAnalysis/Syntax/ParameterSyntax.cs
@@ -1,0 +1,15 @@
+namespace Alto.CodeAnalysis.Syntax
+{
+    public sealed class ParameterSyntax : SyntaxNode
+    {
+        public ParameterSyntax(SyntaxToken identifier, TypeClauseSyntax type)
+        {
+            Identifier = identifier;
+            Type = type;
+        }
+
+        public SyntaxToken Identifier { get; }
+        public TypeClauseSyntax Type { get; }
+        public override SyntaxKind Kind => SyntaxKind.Parameter;
+    }
+}

--- a/Alto/CodeAnalysis/Syntax/SyntaxFacts.cs
+++ b/Alto/CodeAnalysis/Syntax/SyntaxFacts.cs
@@ -67,6 +67,8 @@ namespace Alto.CodeAnalysis.Syntax
                     return SyntaxKind.VarKeyword;
                 case "let":
                     return SyntaxKind.LetKeyword;
+                case "function":
+                    return SyntaxKind.FunctionKeyword;
                 case "if":
                     return SyntaxKind.IfKeyword;
                 case "else":
@@ -140,6 +142,8 @@ namespace Alto.CodeAnalysis.Syntax
                     return "true";
                 case SyntaxKind.VarKeyword:
                     return "var";
+                case SyntaxKind.FunctionKeyword:
+                    return "function";
                 case SyntaxKind.LetKeyword:
                     return "let";
                 case SyntaxKind.IfKeyword:

--- a/Alto/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/Alto/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -43,6 +43,7 @@ namespace Alto.CodeAnalysis.Syntax
         FalseKeyword,
         TrueKeyword,
         VarKeyword,
+        FunctionKeyword,
         LetKeyword,
         IfKeyword,
         ElseKeyword,
@@ -53,8 +54,11 @@ namespace Alto.CodeAnalysis.Syntax
         
         //Nodes
         CompilationUnit,
+        GlobalStatement,
+        FunctionDeclaration,
         ElseClause,
         TypeClause,
+        Parameter,
 
         //Expression Tokens     
         LiteralExpression,

--- a/compiler/AltoRepl.cs
+++ b/compiler/AltoRepl.cs
@@ -175,7 +175,7 @@ namespace REPL
 
             var syntaxTree = SyntaxTree.Parse(text);
 
-            if (syntaxTree.Root.Statement.GetLastToken().IsMissing)
+            if (syntaxTree.Root.Members.Last().GetLastToken().IsMissing)
                 return false;
 
             return true;

--- a/compiler/Repl.cs
+++ b/compiler/Repl.cs
@@ -125,16 +125,17 @@ namespace REPL
                 }
             }
             
-            public int CurrentCharacter { 
-                get => _currentCharacter; 
-                set 
+            public int CurrentCharacter
+            {
+                get => _currentCharacter;
+                set
                 {
                     if (_currentCharacter != value)
                     {
-                        _currentCharacter = value; 
+                        _currentCharacter = value;
                         UpdateCursorPosition();
                     }
-                } 
+                }
             }
         }
 


### PR DESCRIPTION
Add support for function declarations.

## Usage 
You can now declare subroutines (They can't return anything yet)

## Syntax
```
function add(x: int, y: int)
{
    var a = x + y
    print(toString(a))
}

add(15, 36)
```