### PR TITLE
Support `break` and `continue`!

### DIFF
--- a/src/Alto/CodeAnalysis/Binding/BoundDoWhileStatement.cs
+++ b/src/Alto/CodeAnalysis/Binding/BoundDoWhileStatement.cs
@@ -1,8 +1,9 @@
 namespace Alto.CodeAnalysis.Binding
 {
-    internal class BoundDoWhileStatement : BoundStatement
+    internal class BoundDoWhileStatement : BoundLoopStatement
     {
-        public BoundDoWhileStatement(BoundStatement body, BoundExpression condition)
+        public BoundDoWhileStatement(BoundStatement body, BoundExpression condition, 
+            BoundLabel breakLabel, BoundLabel continueLabel) : base(breakLabel, continueLabel)
         {
             Body = body;
             Condition = condition;
@@ -10,7 +11,6 @@ namespace Alto.CodeAnalysis.Binding
 
         public BoundStatement Body { get; }
         public BoundExpression Condition { get; }
-
         public override BoundNodeKind Kind => BoundNodeKind.DoWhileStatement;
     }
 }

--- a/src/Alto/CodeAnalysis/Binding/BoundForStatement.cs
+++ b/src/Alto/CodeAnalysis/Binding/BoundForStatement.cs
@@ -2,10 +2,10 @@ using Alto.CodeAnalysis.Symbols;
 
 namespace Alto.CodeAnalysis.Binding
 {
-    internal sealed class BoundForStatement : BoundStatement
+    internal sealed class BoundForStatement : BoundLoopStatement
     {
-
-        public BoundForStatement(VariableSymbol variable, BoundExpression lowerBound, BoundExpression upperBound, BoundStatement body)
+        public BoundForStatement(VariableSymbol variable, BoundExpression lowerBound, BoundExpression upperBound, BoundStatement body,
+            BoundLabel breakLabel, BoundLabel continueLabel) : base(breakLabel, continueLabel)
         {
             Variable = variable;
             LowerBound = lowerBound;

--- a/src/Alto/CodeAnalysis/Binding/BoundLoopStatement.cs
+++ b/src/Alto/CodeAnalysis/Binding/BoundLoopStatement.cs
@@ -1,0 +1,14 @@
+namespace Alto.CodeAnalysis.Binding
+{
+    internal abstract class BoundLoopStatement : BoundStatement
+    {
+        protected BoundLoopStatement(BoundLabel breakLabel, BoundLabel continueLabel)
+        {
+            BreakLabel = breakLabel;
+            ContinueLabel = continueLabel;
+        }
+
+        public BoundLabel BreakLabel { get; }
+        public BoundLabel ContinueLabel { get; }
+    }
+}

--- a/src/Alto/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Alto/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -131,7 +131,7 @@ namespace Alto.CodeAnalysis.Binding
             if (condition == node.Condition && body == node.Body)
                 return node;
 
-            return new BoundWhileStatement(condition, body);
+            return new BoundWhileStatement(condition, body, node.BreakLabel, node.ContinueLabel);
         }
 
 
@@ -143,7 +143,7 @@ namespace Alto.CodeAnalysis.Binding
             if (condition == node.Condition && body == node.Body)
                 return node;
 
-            return new BoundDoWhileStatement(body, condition);
+            return new BoundDoWhileStatement(body, condition, node.BreakLabel, node.ContinueLabel);
         }
 
         protected virtual BoundStatement RewriteForStatement(BoundForStatement node)
@@ -155,7 +155,7 @@ namespace Alto.CodeAnalysis.Binding
             if (lowerBound == node.LowerBound && upperBound == node.UpperBound && body == node.Body)
                 return node;
 
-            return new BoundForStatement(node.Variable, lowerBound, upperBound, body);
+            return new BoundForStatement(node.Variable, lowerBound, upperBound, body, node.BreakLabel, node.ContinueLabel);
         }
 
         protected virtual BoundStatement RewriteLabelStatement(BoundLabelStatement node)

--- a/src/Alto/CodeAnalysis/Binding/BoundWhileStatement.cs
+++ b/src/Alto/CodeAnalysis/Binding/BoundWhileStatement.cs
@@ -1,8 +1,9 @@
 namespace Alto.CodeAnalysis.Binding
 {
-    internal sealed class BoundWhileStatement : BoundStatement
+    internal sealed class BoundWhileStatement : BoundLoopStatement
     {
-        public BoundWhileStatement(BoundExpression condition , BoundStatement body)
+        public BoundWhileStatement(BoundExpression condition , BoundStatement body, 
+            BoundLabel breakLabel, BoundLabel continueLabel) : base(breakLabel, continueLabel)
         {
             Condition = condition;
             Body = body;

--- a/src/Alto/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Alto/CodeAnalysis/DiagnosticBag.cs
@@ -139,6 +139,12 @@ namespace Alto.CodeAnalysis
             Report(span, message);
         }
 
+        internal void ReportInvalidBreakOrContinue(TextSpan span, string text)
+        {
+            var message = $"Statement '{text}' is not valid outside of loops.";
+            Report(span, message);
+        }
+
         internal void TEMPORARY_ReportFunctionsAreUnsupported(TextSpan span)
         {
             var message = "Functions with returns are not supported yet.";

--- a/src/Alto/CodeAnalysis/Syntax/BreakStatementSyntax.cs
+++ b/src/Alto/CodeAnalysis/Syntax/BreakStatementSyntax.cs
@@ -1,0 +1,14 @@
+namespace Alto.CodeAnalysis.Syntax
+{
+    internal class BreakStatementSyntax : StatementSyntax
+    {
+        public BreakStatementSyntax(SyntaxToken keyword)
+        {
+            Keyword = keyword;
+        }
+
+        public SyntaxToken Keyword { get; }
+
+        public override SyntaxKind Kind => SyntaxKind.BreakStatement;
+    }
+}

--- a/src/Alto/CodeAnalysis/Syntax/ContinueStatementSyntax.cs
+++ b/src/Alto/CodeAnalysis/Syntax/ContinueStatementSyntax.cs
@@ -1,0 +1,14 @@
+namespace Alto.CodeAnalysis.Syntax
+{
+    internal class ContinueStatementSyntax : StatementSyntax
+    {
+        public ContinueStatementSyntax(SyntaxToken keyword)
+        {
+            Keyword = keyword;
+        }
+
+        public SyntaxToken Keyword { get; }
+
+        public override SyntaxKind Kind => SyntaxKind.ContinueStatement;
+    }
+}

--- a/src/Alto/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Alto/CodeAnalysis/Syntax/Parser.cs
@@ -165,6 +165,10 @@ namespace Alto.CodeAnalysis.Syntax
                     return ParseDoWhileStatement();
                 case SyntaxKind.ForKeyword:
                     return ParseForStatement();
+                case SyntaxKind.BreakKeyword:
+                    return ParseBreakStatement();
+                case SyntaxKind.ContinueKeyword:
+                    return ParseContinueStatement();
                 default:
                     return ParseExpressionStatement();
             }
@@ -246,6 +250,18 @@ namespace Alto.CodeAnalysis.Syntax
             var condition = ParseExpression();
 
             return new DoWhileStatementSyntax(doKeyword, body, whileKeyword, condition);
+        }
+
+        private StatementSyntax ParseBreakStatement()
+        {
+            var keyword = MatchToken(SyntaxKind.BreakKeyword);
+            return new BreakStatementSyntax(keyword);
+        }
+
+        private StatementSyntax ParseContinueStatement()
+        {
+            var keyword = MatchToken(SyntaxKind.ContinueKeyword);
+            return new ContinueStatementSyntax(keyword);
         }
 
         private BlockStatementSyntax ParseBlockStatement()

--- a/src/Alto/CodeAnalysis/Syntax/SyntaxFacts.cs
+++ b/src/Alto/CodeAnalysis/Syntax/SyntaxFacts.cs
@@ -81,6 +81,10 @@ namespace Alto.CodeAnalysis.Syntax
                     return SyntaxKind.ForKeyword;
                 case "to":
                     return SyntaxKind.ToKeyword;
+                case "break":
+                    return SyntaxKind.BreakKeyword;
+                case "continue":
+                    return SyntaxKind.ContinueKeyword;
                 default:
                     return SyntaxKind.IdentifierToken;
             }
@@ -158,6 +162,10 @@ namespace Alto.CodeAnalysis.Syntax
                     return "for";
                 case SyntaxKind.ToKeyword:
                     return "to";
+                case SyntaxKind.BreakKeyword:
+                    return "break";
+                case SyntaxKind.ContinueKeyword:
+                    return "continue";
                 case SyntaxKind.CommaToken:
                     return ",";
                 case SyntaxKind.ColonToken:

--- a/src/Alto/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Alto/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -51,6 +51,8 @@ namespace Alto.CodeAnalysis.Syntax
         ForKeyword,
         ToKeyword,
         DoKeyword,
+        BreakKeyword,
+        ContinueKeyword,
         
         //Nodes
         CompilationUnit,
@@ -76,6 +78,8 @@ namespace Alto.CodeAnalysis.Syntax
         IfStatement,
         WhileStatement,
         ForStatement,
-        DoWhileStatement
+        DoWhileStatement,
+        BreakStatement,
+        ContinueStatement,
     }
 }


### PR DESCRIPTION
Yep, does exactly what you'd think it does, standard break and continue.

## Syntax
```js
{
    for i = 0 to 100 {
        if (i > 10)
            break

        if (i % 2 == 0)
            continue

        print(toString(i))
    }
}
```
By the way, I used js syntax highlighting for the above code, I might consider adding Alto to github/linguist when the language is more developed.