### PR TITLE
Add support for `return` statements

### DIFF
--- a/src/Alto/CodeAnalysis/Binding/BoundNodeKind.cs
+++ b/src/Alto/CodeAnalysis/Binding/BoundNodeKind.cs
@@ -28,5 +28,6 @@ namespace Alto.CodeAnalysis.Binding
         GotoStatement,
         ConditionalGotoStatement,
         LabelStatement,
+        ReturnStatement,
     }
 }

--- a/src/Alto/CodeAnalysis/Binding/BoundReturnStatement.cs
+++ b/src/Alto/CodeAnalysis/Binding/BoundReturnStatement.cs
@@ -1,0 +1,13 @@
+namespace Alto.CodeAnalysis.Binding
+{
+    internal sealed class BoundReturnStatement : BoundStatement
+    {
+        public BoundReturnStatement(BoundExpression returnExpression)
+        {
+            ReturnExpression = returnExpression;
+        }
+
+        public override BoundNodeKind Kind => BoundNodeKind.ReturnStatement;
+        public BoundExpression ReturnExpression { get; }
+    }
+}

--- a/src/Alto/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Alto/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -27,6 +27,8 @@ namespace Alto.CodeAnalysis.Binding
                     return RewriteGotoStatement((BoundGotoStatement)node);
                 case BoundNodeKind.ConditionalGotoStatement:
                     return RewriteConditionalGotoStatement((BoundConditionalGotoStatement)node);
+                case BoundNodeKind.ReturnStatement:
+                    return RewriteReturnStatement((BoundReturnStatement)node);
                 case BoundNodeKind.LabelStatement:
                     return RewriteLabelStatement((BoundLabelStatement)node);
                 default:
@@ -156,6 +158,16 @@ namespace Alto.CodeAnalysis.Binding
                 return node;
 
             return new BoundForStatement(node.Variable, lowerBound, upperBound, body, node.BreakLabel, node.ContinueLabel);
+        }
+
+        protected virtual BoundStatement RewriteReturnStatement(BoundReturnStatement node)
+        {
+            var returnExpression = node.ReturnExpression == null ? null : RewriteExpression(node.ReturnExpression);
+            
+            if (returnExpression == node.ReturnExpression)
+                return node;
+
+            return new BoundReturnStatement(returnExpression);
         }
 
         protected virtual BoundStatement RewriteLabelStatement(BoundLabelStatement node)

--- a/src/Alto/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Alto/CodeAnalysis/DiagnosticBag.cs
@@ -93,8 +93,9 @@ namespace Alto.CodeAnalysis
 
         internal void ReportCannotImplicitlyConvert(TextSpan span, TypeSymbol fromType, TypeSymbol targetType)
         {
-            var message = $"Cannot implicitly convert type '{fromType.ToString()}' to type '{targetType.ToString()}'. An explicit conversion exists, are you missing a cast?";
+            var message = $"Cannot implicitly convert type '{fromType.ToString()}' to type '{targetType.ToString()}'. It is an explicit exists, are you missing a cast?";
             Report(span, message);
+
         }
 
         public void ReportCannotAssign(TextSpan span, string name)
@@ -145,15 +146,27 @@ namespace Alto.CodeAnalysis
             Report(span, message);
         }
 
-        internal void ReportInvalidBreakOrContinue(TextSpan span, string text)
+        public void ReportInvalidBreakOrContinue(TextSpan span, string text)
         {
             var message = $"Statement '{text}' is not valid outside of loops.";
             Report(span, message);
         }
 
-        internal void TEMPORARY_ReportFunctionsAreUnsupported(TextSpan span)
+        public void ReportUnexpectedReturn(TextSpan span)
         {
-            var message = "Functions with returns are not supported yet.";
+            var message = "Unexpected return statement. Return statements are only allowed insite functions.";
+            Report(span, message);
+        }
+
+        public void ReportUnexpectedReturnExpression(TextSpan span, TypeSymbol type, string functionName)
+        {
+            var message = $"The function '{functionName}' expects a return value of type 'void', got an expression of type '{type}'.";
+            Report(span, message);
+        }
+
+        public void ReportReturnExpectsAnExpression(TextSpan span, string functionName)
+        {
+            var message = $"The return statement for this function '{functionName}' expects a return expression.";
             Report(span, message);
         }
     }

--- a/src/Alto/CodeAnalysis/Evaluator.cs
+++ b/src/Alto/CodeAnalysis/Evaluator.cs
@@ -57,7 +57,7 @@ namespace Alto.CodeAnalysis
                     case BoundNodeKind.GotoStatement:
                         var gs = (BoundGotoStatement)s;
                         index = labelToIndex[gs.Label];
-                        break;
+                        break;  
                     case BoundNodeKind.ConditionalGotoStatement:
                         var cgs = (BoundConditionalGotoStatement)s;
                         var condition = (bool)EvaluateExpression(cgs.Condition);
@@ -69,6 +69,10 @@ namespace Alto.CodeAnalysis
                     case BoundNodeKind.LabelStatement:
                         index++;
                         break;
+                    case BoundNodeKind.ReturnStatement:
+                        var brs = (BoundReturnStatement)s;
+                        _lastValue = brs.ReturnExpression == null ? null : EvaluateExpression(brs.ReturnExpression);
+                        return _lastValue;
                     default:
                         throw new Exception($"Unexpected node {s.Kind}");
                 }

--- a/src/Alto/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Alto/CodeAnalysis/Syntax/Parser.cs
@@ -129,7 +129,7 @@ namespace Alto.CodeAnalysis.Syntax
                 nodesAndSeparators.Add(parameter);
 
                 if (Current.Kind == SyntaxKind.CommaToken)
-                {
+                {   
                     var comma =  MatchToken(SyntaxKind.CommaToken);
                     nodesAndSeparators.Add(comma);
                 }
@@ -169,6 +169,8 @@ namespace Alto.CodeAnalysis.Syntax
                     return ParseBreakStatement();
                 case SyntaxKind.ContinueKeyword:
                     return ParseContinueStatement();
+                case SyntaxKind.ReturnKeyword:
+                    return ParseReturnStatement();
                 default:
                     return ParseExpressionStatement();
             }
@@ -262,6 +264,20 @@ namespace Alto.CodeAnalysis.Syntax
         {
             var keyword = MatchToken(SyntaxKind.ContinueKeyword);
             return new ContinueStatementSyntax(keyword);
+        }
+
+        private StatementSyntax ParseReturnStatement()
+        {
+            var keyword = MatchToken(SyntaxKind.ReturnKeyword);
+
+            var keywordLine = _text.GetLineIndex(keyword.Span.Start);
+            var currentLine = _text.GetLineIndex(Current.Span.Start);
+            var isEof = Current.Kind == SyntaxKind.EndOfFileToken; 
+            var sameLine = !isEof && currentLine == keywordLine;
+            
+            var expression =  sameLine ? ParseExpression() : null;
+
+            return new ReturnStatementSyntax(keyword, expression);
         }
 
         private BlockStatementSyntax ParseBlockStatement()

--- a/src/Alto/CodeAnalysis/Syntax/ReturnStatementSyntax.cs
+++ b/src/Alto/CodeAnalysis/Syntax/ReturnStatementSyntax.cs
@@ -1,0 +1,15 @@
+namespace Alto.CodeAnalysis.Syntax
+{
+    internal class ReturnStatementSyntax : StatementSyntax
+    {
+        public ReturnStatementSyntax(SyntaxToken keyword, ExpressionSyntax returnExpression)
+        {
+            Keyword = keyword;
+            ReturnExpression = returnExpression;
+        }
+
+        public SyntaxToken Keyword { get; }
+        public ExpressionSyntax ReturnExpression { get; }
+        public override SyntaxKind Kind => SyntaxKind.ReturnStatement;
+    }
+}

--- a/src/Alto/CodeAnalysis/Syntax/SyntaxFacts.cs
+++ b/src/Alto/CodeAnalysis/Syntax/SyntaxFacts.cs
@@ -85,6 +85,8 @@ namespace Alto.CodeAnalysis.Syntax
                     return SyntaxKind.BreakKeyword;
                 case "continue":
                     return SyntaxKind.ContinueKeyword;
+                case "return":
+                    return SyntaxKind.ReturnKeyword;
                 default:
                     return SyntaxKind.IdentifierToken;
             }
@@ -166,6 +168,8 @@ namespace Alto.CodeAnalysis.Syntax
                     return "break";
                 case SyntaxKind.ContinueKeyword:
                     return "continue";
+                case SyntaxKind.ReturnKeyword:
+                    return "return";
                 case SyntaxKind.CommaToken:
                     return ",";
                 case SyntaxKind.ColonToken:

--- a/src/Alto/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Alto/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -54,6 +54,7 @@ namespace Alto.CodeAnalysis.Syntax
         DoKeyword,
         BreakKeyword,
         ContinueKeyword,
+        ReturnKeyword,
         
         //Nodes
         CompilationUnit,
@@ -82,5 +83,6 @@ namespace Alto.CodeAnalysis.Syntax
         DoWhileStatement,
         BreakStatement,
         ContinueStatement,
+        ReturnStatement,
     }
 }


### PR DESCRIPTION
## What this does
We finally allow for return statements in our functions!

## TODO:
- [ ] Do control flow analysis

## Syntax
```ts
function add(x : int, y : int) : int {
    return x + y
}
```
```ts
function hello(name : string) {
    if (name == "test")
        return

    var message = "Hi, " + name + "!"
    print(message)
}
```
