### PR TITLE
Control flow analysis

### DIFF
--- a/src/Alto.Tests/CodeAnalysis/EvaluatorTests.cs
+++ b/src/Alto.Tests/CodeAnalysis/EvaluatorTests.cs
@@ -380,7 +380,7 @@ namespace Alto.Tests.CodeAnalysis
         public void Evaluator_NotAllCodePathsReturn_1()
         {
             var text = @"
-                function foo(x : int) : int {
+                function [foo](x : int) : int {
                     var sum = 0
                     var i = x
                     while true {
@@ -390,7 +390,6 @@ namespace Alto.Tests.CodeAnalysis
                         sum = sum + i
                         i = i - 1
                     }
-                    return -1
                 }
             ";
 
@@ -405,7 +404,7 @@ namespace Alto.Tests.CodeAnalysis
         public void Evaluator_NotAllCodePathsReturn_2()
         {
             var text = @"
-                function foo(x : int) : int {
+                function [foo](x : int) : int {
                     var sum = 0
                     var i = x
                     while true {

--- a/src/Alto.Tests/CodeAnalysis/EvaluatorTests.cs
+++ b/src/Alto.Tests/CodeAnalysis/EvaluatorTests.cs
@@ -375,6 +375,57 @@ namespace Alto.Tests.CodeAnalysis
 
             AssertDiagnostics(text, diagnostics);
         }
+
+        [Fact]
+        public void Evaluator_NotAllCodePathsReturn_1()
+        {
+            var text = @"
+                function foo(x : int) : int {
+                    var sum = 0
+                    var i = x
+                    while true {
+                        if i == 0
+                            break
+        
+                        sum = sum + i
+                        i = i - 1
+                    }
+                    return -1
+                }
+            ";
+
+            var diagnostics = @"
+                Function 'foo' doesn't return on all code paths.
+            ";
+
+            AssertDiagnostics(text, diagnostics);
+        }
+
+        [Fact]
+        public void Evaluator_NotAllCodePathsReturn_2()
+        {
+            var text = @"
+                function foo(x : int) : int {
+                    var sum = 0
+                    var i = x
+                    while true {
+                        if i == 0
+                            break
+        
+                        sum = sum + i
+                        i = i - 1
+                    }
+                    print(toString(x))
+                }
+            ";
+
+            var diagnostics = @"
+                Function 'foo' doesn't return on all code paths.
+            ";
+
+            AssertDiagnostics(text, diagnostics);
+        }
+
         
         private void AssertDiagnostics(string text, string diagnosticText)
         {

--- a/src/Alto/CodeAnalysis/Binding/Binder.cs
+++ b/src/Alto/CodeAnalysis/Binding/Binder.cs
@@ -70,6 +70,9 @@ namespace Alto.CodeAnalysis.Binding
                     var binder = new Binder(parentScope, function);
                     var body = binder.BindStatement(function.Declaration.Body);
                     var loweredBody = Lowerer.Lower(body);
+
+                    if (function.Type != TypeSymbol.Void && !ControlFlowGraph.AllPathsReturn(loweredBody))
+                        binder._diagnostics.ReportNotAllCodePathsReturn(function.Declaration.Identifier.Span, function.Name);
                     
                     functionBodies.Add(function, loweredBody);
                     diagnostics.AddRange(binder.Diagnostics);

--- a/src/Alto/CodeAnalysis/Binding/BoundNodePrinter.cs
+++ b/src/Alto/CodeAnalysis/Binding/BoundNodePrinter.cs
@@ -108,6 +108,9 @@ namespace Alto.CodeAnalysis.Binding
                 case BoundNodeKind.LabelStatement:
                     WriteLabelStatement((BoundLabelStatement)node, writer);
                     break;
+                case BoundNodeKind.ReturnStatement:
+                    WriteReturnStatement((BoundReturnStatement)node, writer);
+                    break;
                 default:
                     throw new Exception($"Unexprected BoundNodeKind {node.Kind}");
             }
@@ -198,6 +201,14 @@ namespace Alto.CodeAnalysis.Binding
             }
 
             writer.WritePunctuation(SyntaxKind.CloseParenthesesToken);   
+        }
+
+        private static void WriteReturnStatement(BoundReturnStatement node, IndentedTextWriter writer)
+        {
+            writer.WriteKeyword(SyntaxKind.ReturnKeyword);
+            writer.WriteWhitespace();
+            writer.Write(node.ReturnExpression);
+            writer.WriteLine();
         }
 
         private static void WriteConversionExpression(BoundConversionExpression node, IndentedTextWriter writer)

--- a/src/Alto/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Alto/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -62,6 +62,20 @@ namespace Alto.CodeAnalysis.Binding
             return graphBuilder.Build(blocks);
         }
 
+        public static bool AllPathsReturn(BoundBlockStatement body)
+        {
+            var graph = Create(body);
+
+            foreach (var branch in graph.End.Incoming)
+            {
+                var stmt = branch.From.Statements.Last();
+                if (stmt.Kind != BoundNodeKind.ReturnStatement)
+                    return false;
+            }
+
+            return true;
+        }
+
         public sealed class BasicBlockBuilder
         {
             private BasicBlock _current;

--- a/src/Alto/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Alto/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Alto.CodeAnalysis.Symbols;
+using Alto.CodeAnalysis.Syntax;
+
+namespace Alto.CodeAnalysis.Binding
+{
+    internal sealed class ControlFlowGraph
+    {
+        private ControlFlowGraph(BasicBlock start, BasicBlock end, List<BasicBlock> blocks, List<BasicBlockBranch> branches)
+        {
+            Start = start;
+            End = end;
+            Blocks = blocks;
+            Branches = branches;
+        }
+
+        public BasicBlock Start { get; }
+        public BasicBlock End { get; }
+        public List<BasicBlock> Blocks { get; }
+        public List<BasicBlockBranch> Branches { get; }
+
+        public void WriteTo(TextWriter writer)
+        {
+            writer.WriteLine("digraph G {");
+            
+            var blockIds = new Dictionary<BasicBlock, string>();
+            for (int i = 0; i < Blocks.Count; i++)
+            {
+                var block = Blocks[i];
+                var id = "N" + i.ToString();
+                blockIds.Add(block, id);
+            }
+
+            foreach (var block in Blocks)
+            {
+                var id = blockIds[block];
+                var label = block.ToString().Replace(System.Environment.NewLine, "\\l");
+                writer.WriteLine($"    {id} [label = \"{label}\" shape = box]");
+            }
+
+            foreach (var branch in Branches)
+            {
+                var fromId = blockIds[branch.From];
+                var toId = blockIds[branch.To];
+                var label = branch.Condition == null ? string.Empty : branch.Condition.ToString();
+                writer.WriteLine($"    {fromId} -> {toId} [label = \"{label}\"]");
+            }
+
+            writer.WriteLine("}");
+        }
+
+        public static ControlFlowGraph Create(BoundBlockStatement body)
+        {
+            var blockBuilder = new BasicBlockBuilder();
+            var blocks = blockBuilder.Build(body);
+
+            var graphBuilder = new GraphBuilder();
+            return graphBuilder.Build(blocks);
+        }
+
+        public sealed class BasicBlockBuilder
+        {
+            private BasicBlock _current;
+            private List<BasicBlock> _blocks = new List<BasicBlock>();
+            private List<BoundStatement> _statements = new List<BoundStatement>();
+
+            public List<BasicBlock> Build(BoundBlockStatement block)
+            {
+                foreach (var statement in block.Statements)
+                {
+                    switch (statement.Kind)
+                    {
+                        case BoundNodeKind.ExpressionStatement:
+                        case BoundNodeKind.VariableDeclaration:
+                            _statements.Add(statement);
+                            break;
+                        case BoundNodeKind.GotoStatement:
+                        case BoundNodeKind.ConditionalGotoStatement:
+                        case BoundNodeKind.ReturnStatement:
+                            _statements.Add(statement);
+                            StartBlock();
+                            break;
+                        case BoundNodeKind.LabelStatement:
+                            StartBlock();
+                            _statements.Add(statement);
+                            break;
+                        default:
+                            throw new Exception($"Unexpected statement {statement.Kind}");
+                    }
+                }
+
+                EndBlock();
+                
+                return _blocks;
+            }
+
+            private void StartBlock()
+            {
+                EndBlock();
+            }
+
+            private void EndBlock()
+            {
+                if (_statements.Count > 0)
+                {
+                    var block = new BasicBlock();
+                    block.Statements.AddRange(_statements);
+                    _blocks.Add(block);
+                    _statements.Clear();
+                }
+            }
+        }
+
+        public sealed class GraphBuilder
+        {
+            private Dictionary<BoundStatement, BasicBlock> _blockFromStatement = new Dictionary<BoundStatement, BasicBlock>();
+            private Dictionary<BoundLabel, BasicBlock> _blockFromLabel = new Dictionary<BoundLabel, BasicBlock>();
+            private List<BasicBlockBranch> _branches = new List<BasicBlockBranch>();
+            private BasicBlock _start = new BasicBlock(isStart: true);
+            private BasicBlock _end = new BasicBlock(isStart: false);
+
+            public ControlFlowGraph Build(List<BasicBlock> blocks)
+            {   
+                if (!blocks.Any())
+                    Connect(_start, _end);
+                else
+                    Connect(_start, blocks.First());
+
+                foreach (var block in blocks)
+                {
+                    foreach (var statement in block.Statements)
+                    {
+                        _blockFromStatement.Add(statement, block);
+                        if (statement is BoundLabelStatement ls)
+                            _blockFromLabel.Add(ls.Label, block);
+                    }
+                }
+
+                for (int i = 0; i < blocks.Count; i++)
+                {
+                    var current = blocks[i];
+                    var next = i == blocks.Count - 1 ? _end : blocks[i + 1];
+                    foreach (var statement in current.Statements)
+                    {
+                        var isLast = statement == current.Statements.Last();
+                        Walk(statement, current, next, isLast);
+                    }
+                }
+
+                blocks.Insert(0, _start);
+                blocks.Add(_end);
+
+                return new ControlFlowGraph(_start, _end, blocks, _branches);
+            }
+
+            private void Walk(BoundStatement statement, BasicBlock current, BasicBlock next, bool isLast)
+            {
+                switch (statement.Kind)
+                {
+                    case BoundNodeKind.ExpressionStatement:
+                    case BoundNodeKind.LabelStatement:
+                    case BoundNodeKind.VariableDeclaration:
+                        if (isLast)
+                            Connect(current, next);
+                        break;
+                    case BoundNodeKind.GotoStatement:
+                        var GotoStatement = (BoundGotoStatement)statement;
+                        var toBlock = _blockFromLabel[GotoStatement.Label];
+                        Connect(current, toBlock);
+                        break;
+                    case BoundNodeKind.ConditionalGotoStatement:
+                        var conditionalGoto = (BoundConditionalGotoStatement)statement;
+                        var thenBlock = _blockFromLabel[conditionalGoto.Label];
+                        var elseBlock = next;
+                        var negCondition = Negate(conditionalGoto.Condition);
+                        var thenCondition = conditionalGoto.JumpIfTrue ? conditionalGoto.Condition : negCondition;
+                        var elseCondition = conditionalGoto.JumpIfTrue ? negCondition : conditionalGoto.Condition;
+                        Connect(current, thenBlock, condition: thenCondition);
+                        Connect(current, elseBlock, condition: elseCondition);
+                        break;
+                    case BoundNodeKind.ReturnStatement:
+                        Connect(current, _end);
+                        break;
+                    default:
+                        throw new Exception($"Unexpected statement {statement.Kind}");
+                }
+            }
+
+            private void Connect(BasicBlock from, BasicBlock to, BoundExpression condition = null)
+            {
+                if (condition is BoundLiteralExpression l)
+                {
+                    var v = (bool)l.Value;
+                    if (v)
+                        condition = null;
+                    else
+                        return;
+                }
+
+                var branch = new BasicBlockBranch(from, to, null);
+                from.Outgoing.Add(branch);
+                to.Incoming.Add(branch);
+                _branches.Add(branch);
+            }
+
+            private BoundExpression Negate(BoundExpression expression)
+            {
+                if (expression is BoundLiteralExpression literal)
+                {
+                    var value = (bool)literal.Value;
+                    return new BoundLiteralExpression(!value);
+                }
+
+                var unaryOp = BoundUnaryOperator.Bind(SyntaxKind.BangToken, TypeSymbol.Bool);
+                return new BoundUnaryExpression(unaryOp, expression);
+            }
+        }
+
+        public sealed class BasicBlock
+        {
+            public BasicBlock()
+            {
+            }
+
+            public BasicBlock(bool isStart)
+            {
+                IsStart = isStart;
+                IsEnd = !isStart;
+            }
+
+            public List<BoundStatement> Statements { get; } = new List<BoundStatement>();
+            public List<BasicBlockBranch> Incoming { get; } = new List<BasicBlockBranch>();
+            public List<BasicBlockBranch> Outgoing { get; } = new List<BasicBlockBranch>();
+            public bool IsStart { get; }
+            public bool IsEnd { get; }
+
+            public override string ToString()
+            {
+                if (IsStart)
+                    return "<Start>";
+                else if (IsEnd)
+                    return "<End>";
+                
+                using (var w = new StringWriter())
+                {
+                    foreach (var statement in Statements)
+                        statement.WriteTo(w);
+
+                    return w.ToString();
+                }
+            }
+        }
+
+        public sealed class BasicBlockBranch
+        {
+            public BasicBlockBranch(BasicBlock from, BasicBlock to, BoundExpression condition)
+            {
+                From = from;
+                To = to;
+                Condition = condition;
+            }
+
+            public BasicBlock From { get; }
+            public BasicBlock To { get; }
+            public BoundExpression Condition { get; }
+            public override string ToString()
+            {
+                if (Condition == null)
+                    return string.Empty;
+
+                return Condition.ToString();
+            }
+        }
+    }
+}

--- a/src/Alto/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Alto/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -150,6 +150,16 @@ namespace Alto.CodeAnalysis.Binding
                         Walk(statement, current, next, isLast);
                     }
                 }
+                
+            Scan:
+                foreach (var block in blocks)
+                {
+                    if (!block.Incoming.Any())
+                    {
+                        RemoveBlock(blocks, block);
+                        goto Scan;
+                    }
+                }
 
                 blocks.Insert(0, _start);
                 blocks.Add(_end);
@@ -205,6 +215,23 @@ namespace Alto.CodeAnalysis.Binding
                 from.Outgoing.Add(branch);
                 to.Incoming.Add(branch);
                 _branches.Add(branch);
+            }
+
+            private void RemoveBlock(List<BasicBlock> blocks, BasicBlock block)
+            {
+                foreach (var branch in block.Incoming)
+                {
+                    branch.From.Outgoing.Remove(branch);
+                    _branches.Remove(branch);
+                }
+
+                foreach (var branch in block.Outgoing)
+                {
+                    branch.To.Incoming.Remove(branch);
+                    _branches.Remove(branch);
+                }
+
+                blocks.Remove(block);
             }
 
             private BoundExpression Negate(BoundExpression expression)

--- a/src/Alto/CodeAnalysis/Compilation.cs
+++ b/src/Alto/CodeAnalysis/Compilation.cs
@@ -58,6 +58,19 @@ namespace Alto.CodeAnalysis
                 return new EvaluationResult(diagnostics, null);
 
             var program = Binder.BindProgram(GlobalScope);
+
+            var appPath = Environment.GetCommandLineArgs()[0];
+            var appDir = Path.GetDirectoryName(appPath);
+            var cfgPath = Path.Combine(appDir, "cfg.dot");
+
+            var cfgStatement = !program.Statement.Statements.Any() && program.FunctionBodies.Any() 
+                                ? program.FunctionBodies.Last().Value 
+                                : program.Statement;
+
+            var cfg = ControlFlowGraph.Create(cfgStatement);
+            using (var writer = new StreamWriter(cfgPath))
+                cfg.WriteTo(writer);
+
             if (program.Diagnostics.Any())
                 return new EvaluationResult(program.Diagnostics.ToImmutableArray(), null);
 

--- a/src/Alto/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Alto/CodeAnalysis/DiagnosticBag.cs
@@ -85,6 +85,12 @@ namespace Alto.CodeAnalysis
             Report(span, message);
         }
 
+        internal void ReportNotAllCodePathsReturn(TextSpan span, string name)
+        {
+            var message = $"Function '{name}' doesn't return on all code paths.";
+            Report(span, message);
+        }
+
         public void ReportCannotConvert(TextSpan span, TypeSymbol fromType, TypeSymbol targetType)
         {
             var message = $"Cannot convert type '{fromType.ToString()}' to type '{targetType.ToString()}'.";


### PR DESCRIPTION
## Control Flow Analysis
We can now check if a function returns a value on all code paths.

The following function will get this error `Function 'foo' doesn't return on all code paths.`, because it doesn't return on all code paths. This analyzer is only implemented for functions with return values that are not of type `void`, see the `BindProgram` method in the binder for more information on that.
```ts
function foo(x : int) : int {
    var sum = 0
    var i = x
    while true {
        if i == 0
            break
        
        sum = sum + i
        i = i - 1
    }
    print("foo: " + toString(sum))
}
```

## Control Flow Graphs
Added an API for the creation of control flow graphs. Which also automatically removes obsolete nodes from the graph.
![cfg](https://user-images.githubusercontent.com/68369112/123511865-071dfc00-d652-11eb-9171-97979d19f928.jpg)