### PR TITLE
Add support for optional parameters

### DIFF
--- a/src/Alto.Tests/CodeAnalysis/EvaluatorTests.cs
+++ b/src/Alto.Tests/CodeAnalysis/EvaluatorTests.cs
@@ -303,16 +303,17 @@ namespace Alto.Tests.CodeAnalysis
         public void Evaluator_FunctionParameters_Reports_NoInfiniteLoop()
         {
             var text = @"
-                function test(name: string[[[=]]][)]
+                function test(name: string[[[*]]][[)]]
                 {
                     print(""Hi "" + name + ""!"" )
                 }[]
             ";
 
             var diagnostics = @"
-                Unexpected token <EqualsToken>, expected <CloseParenthesesToken>.
-                Unexpected token <EqualsToken>, expected <OpenBraceToken>.
-                Unexpected token <EqualsToken>, expected <IdentifierToken>.
+                Unexpected token <StarToken>, expected <CloseParenthesesToken>.
+                Unexpected token <StarToken>, expected <OpenBraceToken>.
+                Unexpected token <StarToken>, expected <IdentifierToken>.
+                Unexpected token <CloseParenthesesToken>, expected <IdentifierToken>.
                 Unexpected token <CloseParenthesesToken>, expected <IdentifierToken>.
                 Unexpected token <EndOfFileToken>, expected <CloseBraceToken>.
             ";

--- a/src/Alto.Tests/CodeAnalysis/EvaluatorTests.cs
+++ b/src/Alto.Tests/CodeAnalysis/EvaluatorTests.cs
@@ -88,6 +88,9 @@ namespace Alto.Tests.CodeAnalysis
         [InlineData("\"test\" ~= \"idk\"", true)]
         [InlineData("{ var i = 0 while i < 5 { i = i + 1 if i == 5 continue } i }", 5)]
         [InlineData("{ var i = 0 do { i = i + 1 if i == 5 continue } while i < 5 i }", 5)]
+        [InlineData("function add(x : int = 5, y : int = 10) : int { return x + y } add()", 15)]
+        [InlineData("function add(x : int = 5, y : int = 10) : int { return x + y } add(7)", 17)]
+        [InlineData("function add(x : int = 5, y : int = 10) : int { return x + y } add(4, 2)", 6)]
         public void Evaluator_Computes_CorrectValues(string text, object expectedValue)
         {
             AssertValue(text, expectedValue);
@@ -316,6 +319,23 @@ namespace Alto.Tests.CodeAnalysis
                 Unexpected token <CloseParenthesesToken>, expected <IdentifierToken>.
                 Unexpected token <CloseParenthesesToken>, expected <IdentifierToken>.
                 Unexpected token <EndOfFileToken>, expected <CloseBraceToken>.
+            ";
+
+            AssertDiagnostics(text, diagnostics);
+        }
+
+        [Fact]
+        public void Evaluator_FunctionOptionalParameters_MustAppearLast()
+        {
+            var text = @"
+                function test(x: int = 5, [y : int])
+                {
+                    print(toString(x + y))
+                }
+            ";
+
+            var diagnostics = @"
+                Optional parameters must appear after required parameters.
             ";
 
             AssertDiagnostics(text, diagnostics);

--- a/src/Alto/CodeAnalysis/Binding/Binder.cs
+++ b/src/Alto/CodeAnalysis/Binding/Binder.cs
@@ -557,26 +557,14 @@ namespace Alto.CodeAnalysis.Binding
                 }
             }
 
-            // add optional parameters
-            /*var optionalParameters = function.Parameters.Where(p => p.IsOptional == true); 
-            for (int i = 0; i < optionalParameters.Count() - syntax.Arguments.Count; i++)
-            {
-                var parameter = optionalParameters.ToArray()[i];
-                var v = parameter.OptionalValue;
-                boundArguments.Add(v);
-            }
-            */
-
-            for (int i = 0; i < function.Parameters.Length; i++)
+            for (var i = syntax.Arguments.Count(); i < function.Parameters.Count(); i++)
             {
                 var parameter = function.Parameters[i];
-                if (syntax.Arguments.Count < i)
+                if (parameter.OptionalValue != null && parameter.IsOptional)
                 {
-                    if (parameter.IsOptional == true)
-                    {
-                        // add the arg
-                        boundArguments.Add(parameter.OptionalValue);
-                    }
+                    // add the v to the args
+                    var v = parameter.OptionalValue;
+                    boundArguments.Add(v);
                 }
             }
 

--- a/src/Alto/CodeAnalysis/Binding/Binder.cs
+++ b/src/Alto/CodeAnalysis/Binding/Binder.cs
@@ -558,12 +558,26 @@ namespace Alto.CodeAnalysis.Binding
             }
 
             // add optional parameters
-            var optionalParameters = function.Parameters.Where(p => p.IsOptional == true); 
+            /*var optionalParameters = function.Parameters.Where(p => p.IsOptional == true); 
             for (int i = 0; i < optionalParameters.Count() - syntax.Arguments.Count; i++)
             {
                 var parameter = optionalParameters.ToArray()[i];
                 var v = parameter.OptionalValue;
                 boundArguments.Add(v);
+            }
+            */
+
+            for (int i = 0; i < function.Parameters.Length; i++)
+            {
+                var parameter = function.Parameters[i];
+                if (syntax.Arguments.Count < i)
+                {
+                    if (parameter.IsOptional == true)
+                    {
+                        // add the arg
+                        boundArguments.Add(parameter.OptionalValue);
+                    }
+                }
             }
 
             if (hasErrors)

--- a/src/Alto/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Alto/CodeAnalysis/DiagnosticBag.cs
@@ -73,6 +73,12 @@ namespace Alto.CodeAnalysis
             Report(span, message);
         }
 
+        internal void ReportOptionalParametersMustAppearLast(TextSpan span)
+        {
+            var message = $"Optional parameters must appear after required parameters.";
+            Report(span, message);
+        }
+
         public void ReportSymbolAlreadyDeclared(TextSpan span, string name)
         {
             var message = $"'{name}' is already declared in the current scope.";

--- a/src/Alto/CodeAnalysis/Symbols/BuiltInFunctions.cs
+++ b/src/Alto/CodeAnalysis/Symbols/BuiltInFunctions.cs
@@ -8,9 +8,9 @@ namespace Alto.CodeAnalysis.Symbols
 {
     internal static class BuiltInFunctions
     {
-        public static readonly FunctionSymbol Print = new FunctionSymbol("print", ImmutableArray.Create(new ParameterSymbol("text", TypeSymbol.String)), TypeSymbol.Void);
+        public static readonly FunctionSymbol Print = new FunctionSymbol("print", ImmutableArray.Create(new ParameterSymbol("text", TypeSymbol.String, false)), TypeSymbol.Void);
         public static readonly FunctionSymbol ReadLine = new FunctionSymbol("readLine", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.String);
-        public static readonly FunctionSymbol Random = new FunctionSymbol("random", ImmutableArray.Create(new ParameterSymbol("min", TypeSymbol.Int), new ParameterSymbol("max", TypeSymbol.Int)), TypeSymbol.Int);
+        public static readonly FunctionSymbol Random = new FunctionSymbol("random", ImmutableArray.Create(new ParameterSymbol("min", TypeSymbol.Int, false), new ParameterSymbol("max", TypeSymbol.Int, false)), TypeSymbol.Int);
         
         internal static IEnumerable<FunctionSymbol> GetAll()
         {

--- a/src/Alto/CodeAnalysis/Symbols/ParameterSymbol.cs
+++ b/src/Alto/CodeAnalysis/Symbols/ParameterSymbol.cs
@@ -1,12 +1,24 @@
+using Alto.CodeAnalysis.Binding;
+
 namespace Alto.CodeAnalysis.Symbols
 {
     public sealed class ParameterSymbol : LocalVariableSymbol
     {
-        public ParameterSymbol(string name, TypeSymbol type)
+        public ParameterSymbol(string name, TypeSymbol type, bool isOptional = false)
             : base(name: name, isReadOnly: true, type: type)
         {
+            IsOptional = isOptional;
         }
 
+        internal ParameterSymbol(string name, TypeSymbol type, bool isOptional, BoundExpression optionalValue = null)
+            : base(name: name, isReadOnly: true, type: type)
+        {
+            IsOptional = isOptional;
+            OptionalValue = optionalValue;
+        }
+
+        public bool IsOptional { get; }
+        internal BoundExpression OptionalValue { get; }
         public override SymbolKind Kind => SymbolKind.Parameter;
     }
 }

--- a/src/Alto/CodeAnalysis/Syntax/ParameterSyntax.cs
+++ b/src/Alto/CodeAnalysis/Syntax/ParameterSyntax.cs
@@ -2,14 +2,18 @@ namespace Alto.CodeAnalysis.Syntax
 {
     public sealed class ParameterSyntax : SyntaxNode
     {
-        public ParameterSyntax(SyntaxToken identifier, TypeClauseSyntax type)
+        public ParameterSyntax(SyntaxToken identifier, TypeClauseSyntax type, bool isOptional, ExpressionSyntax optionalExpression)
         {
             Identifier = identifier;
             Type = type;
+            IsOptional = isOptional;
+            OptionalExpression = optionalExpression;
         }
 
         public SyntaxToken Identifier { get; }
         public TypeClauseSyntax Type { get; }
+        public bool IsOptional { get; }
+        public ExpressionSyntax OptionalExpression { get; }
         public override SyntaxKind Kind => SyntaxKind.Parameter;
     }
 }

--- a/src/Alto/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Alto/CodeAnalysis/Syntax/Parser.cs
@@ -159,7 +159,7 @@ namespace Alto.CodeAnalysis.Syntax
             // have to make sure it's optional
             SyntaxToken equalsToken = null;
             bool isOptional = false;
-            var k = Peek(0).Kind; // NOTE: Equals token was already consumed, idk where...
+            var k = Peek(0).Kind;
             if (k == SyntaxKind.EqualsToken)
             {
                 equalsToken = MatchToken(SyntaxKind.EqualsToken);

--- a/src/Alto/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Alto/CodeAnalysis/Syntax/Parser.cs
@@ -123,6 +123,7 @@ namespace Alto.CodeAnalysis.Syntax
             var nodesAndSeparators = ImmutableArray.CreateBuilder<SyntaxNode>();
 
             var parseNextParameter = true;
+            ParameterSyntax lastParamerer = null;
             while (parseNextParameter &&
                    Current.Kind != SyntaxKind.CloseParenthesesToken &&
                    Current.Kind != SyntaxKind.EndOfFileToken)
@@ -139,6 +140,12 @@ namespace Alto.CodeAnalysis.Syntax
                 {
                     parseNextParameter = false;
                 }
+
+                if (lastParamerer != null)
+                    if (lastParamerer.IsOptional && !parameter.IsOptional)
+                        _diagnostics.ReportOptionalParametersMustAppearLast(parameter.Span);
+
+                lastParamerer = parameter;
             }
             return new SeparatedSyntaxList<ParameterSyntax>(nodesAndSeparators.ToImmutable());
         }


### PR DESCRIPTION
## TODO

- [x] Parse `em
- [x] Bind `em
- [x] Evaluate `em
- [x] Test `em
- [x] Make sure that optional params can only be the last ones
- [x] Fix test `Evaluator_FunctionParameters_Reports_NoInfiniteLoop`

## Syntax
```ts
function foo(x : int, y : int = 10) {
    print(toString(x + y))
}
```
```ts
foo(5) // =>15
foo(5, 5) // => 10
```