### PR TITLE
Make all built-in functions and conversions lower-case

### DIFF
--- a/samples/guess/guess.ao
+++ b/samples/guess/guess.ao
@@ -19,7 +19,7 @@ function run() {
 
     print("Would you like to play again? Reply with a y/n")
 
-    var playAgain = readLine() == "y"
+    var playAgain = readline() == "y"
     if (playAgain)
         run()
 }

--- a/src/Alto.Tests/CodeAnalysis/EvaluatorTests.cs
+++ b/src/Alto.Tests/CodeAnalysis/EvaluatorTests.cs
@@ -435,7 +435,7 @@ namespace Alto.Tests.CodeAnalysis
                         sum = sum + i
                         i = i - 1
                     }
-                    print(toString(x))
+                    print(tostring(x))
                 }
             ";
 

--- a/src/Alto/CodeAnalysis/Binding/Binder.cs
+++ b/src/Alto/CodeAnalysis/Binding/Binder.cs
@@ -422,7 +422,7 @@ namespace Alto.CodeAnalysis.Binding
         private BoundExpression BindNameExpression(NameExpressionSyntax syntax) 
         {
             var name = syntax.IdentifierToken.Text;
-
+ 
             if (syntax.IdentifierToken.IsMissing)
                 return new BoundErrorExpression();
                 
@@ -616,11 +616,11 @@ namespace Alto.CodeAnalysis.Binding
         {
             switch (name)
             {
-                case "toBool":
+                case "tobool":
                     return TypeSymbol.Bool;
-                case "toString":
+                case "tostring":
                     return TypeSymbol.String;
-                case "toInt":
+                case "toint":
                     return TypeSymbol.Int;
             }
 

--- a/src/Alto/CodeAnalysis/Symbols/BuiltInFunctions.cs
+++ b/src/Alto/CodeAnalysis/Symbols/BuiltInFunctions.cs
@@ -9,7 +9,7 @@ namespace Alto.CodeAnalysis.Symbols
     internal static class BuiltInFunctions
     {
         public static readonly FunctionSymbol Print = new FunctionSymbol("print", ImmutableArray.Create(new ParameterSymbol("text", TypeSymbol.String, false)), TypeSymbol.Void);
-        public static readonly FunctionSymbol ReadLine = new FunctionSymbol("readLine", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.String);
+        public static readonly FunctionSymbol ReadLine = new FunctionSymbol("readline", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.String);
         public static readonly FunctionSymbol Random = new FunctionSymbol("random", ImmutableArray.Create(new ParameterSymbol("min", TypeSymbol.Int, false), new ParameterSymbol("max", TypeSymbol.Int, false)), TypeSymbol.Int);
         
         internal static IEnumerable<FunctionSymbol> GetAll()


### PR DESCRIPTION
## Syntax
```ts
print(tostring(toint(readline()) + toint("55") ) )
```
## Old Syntax
```ts
print(toString(toInt(readLine()) + toInt("55") ) )
```