### PR TITLE
The binder fails when a function's text is null

### DIFF
--- a/src/Alto/CodeAnalysis/Binding/Binder.cs
+++ b/src/Alto/CodeAnalysis/Binding/Binder.cs
@@ -120,7 +120,7 @@ namespace Alto.CodeAnalysis.Binding
 
             var function = new FunctionSymbol(syntax.Identifier.Text, parameters.ToImmutable(), type, syntax);
 
-            if (!_scope.TryDeclareFunction(function))
+            if (function.Declaration.Identifier.Text != null && !_scope.TryDeclareFunction(function))
                 _diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Span, function.Name);
         }
 
@@ -541,7 +541,7 @@ namespace Alto.CodeAnalysis.Binding
 
                 _diagnostics.ReportWrongArgumentCount(span, function.Name, parameterCount, syntax.Arguments.Count);
                 return new BoundErrorExpression();
-            }
+            }       
             
             bool hasErrors = false;
             for (var i = 0; i < syntax.Arguments.Count; i++)


### PR DESCRIPTION
This PR should fix that.