### PR TITLE
Allow for nested functions

### DIFF
--- a/src/Alto.Tests/Alto.Tests.csproj
+++ b/src/Alto.Tests/Alto.Tests.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Alto\Alto.csproj" />
-    <ProjectReference Include="..\ai\ai.csproj" />
+    <ProjectReference Include="..\aoi\aoi.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Alto.Tests/CodeAnalysis/EvaluatorTests.cs
+++ b/src/Alto.Tests/CodeAnalysis/EvaluatorTests.cs
@@ -91,6 +91,11 @@ namespace Alto.Tests.CodeAnalysis
         [InlineData("function add(x : int = 5, y : int = 10) : int { return x + y } add()", 15)]
         [InlineData("function add(x : int = 5, y : int = 10) : int { return x + y } add(7)", 17)]
         [InlineData("function add(x : int = 5, y : int = 10) : int { return x + y } add(4, 2)", 6)]
+        [InlineData("{ function add(x : int = 2, y : int = 2) : int { return x + y } add() }", 4)]
+        [InlineData("{ function add(x : int = 2, y : int = 2) : int { return x + y } add(3) }", 5)]
+        [InlineData("{ function add(x : int = 2, y : int = 2) : int { return x + y } add(3, 10) }", 13)]
+        [InlineData("{ function add(x : int = 2, y : int = 2) : int { return x + y } { add(10, 10) } }", 20)]
+        [InlineData("{ function add(x : int = 2, y : int = 2) : int { return x + y } { { add(10, 10) } } }", 20)]
         public void Evaluator_Computes_CorrectValues(string text, object expectedValue)
         {
             AssertValue(text, expectedValue);
@@ -111,7 +116,7 @@ namespace Alto.Tests.CodeAnalysis
             ";
 
             var diagnostics = @"
-                'x' is already declared in the current scope.
+                A symbol with name 'x' is already declared.
             ";
 
             AssertDiagnostics(text, diagnostics);
@@ -511,6 +516,29 @@ namespace Alto.Tests.CodeAnalysis
 
             var diagnostics = @"
                 Cannot find file 'myFoobarLib' to import.
+            ";
+
+            AssertDiagnostics(text, diagnostics);
+        }
+
+        [Fact]
+        public void Evaluator_NestedFunctions1()
+        {
+            var text = @"
+                {
+                    {
+                        function myFunc(text : string) {
+                            print(text)
+                        }
+                    }
+
+                    var txt = ""Test""
+                    [myFunc](txt)
+                }
+            ";
+
+            var diagnostics = @"
+                Function 'myFunc' is not defined in the current scope.
             ";
 
             AssertDiagnostics(text, diagnostics);

--- a/src/Alto/CodeAnalysis/Binding/Binder.cs
+++ b/src/Alto/CodeAnalysis/Binding/Binder.cs
@@ -405,14 +405,14 @@ namespace Alto.CodeAnalysis.Binding
             {
                 var funcSymbol = BindFunctionDeclaration(function, syntax.SyntaxTree, declare: false);
                 // TODO: Also have to check for duplicate names
-
+                if (!LocalFunctionNameIsUnique(funcSymbol))
+                    _diagnostics.ReportSymbolAlreadyDeclared(function.Identifier.Location, funcSymbol.Name);
+                
                 var body = BindStatement(function.Body);
                 var loweredBody = Lowerer.Lower(body);
 
                 if (funcSymbol.Type != TypeSymbol.Void && !ControlFlowGraph.AllPathsReturn(loweredBody))
                     _diagnostics.ReportNotAllCodePathsReturn(function.Identifier.Location, funcSymbol.Name);
-                
-                //functionBodies.Add(function, loweredBody);
                 
                 if (!_localFunctions.ContainsKey(_scope))
                 {
@@ -825,6 +825,16 @@ namespace Alto.CodeAnalysis.Binding
             }
 
             return symbol;
+        }
+
+        private bool LocalFunctionNameIsUnique(FunctionSymbol function)
+        {
+            foreach (var localScope in _localFunctions)
+                foreach (var func in localScope.Value)
+                    if (func.Item1.Name == function.Name)
+                        return false;
+
+            return true;
         }
     }
 }

--- a/src/Alto/CodeAnalysis/Binding/Binder.cs
+++ b/src/Alto/CodeAnalysis/Binding/Binder.cs
@@ -408,11 +408,13 @@ namespace Alto.CodeAnalysis.Binding
             {
                 var funcSymbol = BindFunctionDeclaration(function, syntax.SyntaxTree, declare: false);
 
+                Binder binder = new Binder(_scope, funcSymbol, CheckCallsiteTrees);
+
                 // TODO: Also have to check for duplicate names
                 if (!LocalFunctionNameIsUnique(funcSymbol))
                     _diagnostics.ReportSymbolAlreadyDeclared(function.Identifier.Location, funcSymbol.Name);
                 
-                var body = BindBlockStatement(function.Body, funcSymbol.Parameters);
+                var body = binder.BindBlockStatement(function.Body, funcSymbol.Parameters);
                 var loweredBody = Lowerer.Lower(body);
 
                 if (funcSymbol.Type != TypeSymbol.Void && !ControlFlowGraph.AllPathsReturn(loweredBody))

--- a/src/Alto/CodeAnalysis/Binding/Binder.cs
+++ b/src/Alto/CodeAnalysis/Binding/Binder.cs
@@ -801,16 +801,26 @@ namespace Alto.CodeAnalysis.Binding
             var symbol = _scope.TryLookupSymbol(name);
             if (symbol == null)
             {
-                if (_localFunctions.ContainsKey(_scope))
+                
+            }
+
+            if (symbol == null)
+            {
+                var scope = _scope;
+                while (scope != null)
                 {
-                    foreach (var body in _localFunctions[_scope])
+                    if (_localFunctions.ContainsKey(scope))
                     {
-                        if (body.Item1.Name == name)
+                        foreach (var body in _localFunctions[scope])
                         {
-                            symbol = body.Item1;
-                            break;
+                            if (body.Item1.Name == name)
+                            {
+                                symbol = body.Item1;
+                                return symbol;
+                            }
                         }
                     }
+                    scope = scope.Parent;
                 }
             }
 

--- a/src/Alto/CodeAnalysis/Compilation.cs
+++ b/src/Alto/CodeAnalysis/Compilation.cs
@@ -14,6 +14,7 @@ namespace Alto.CodeAnalysis
     public sealed class Compilation
     {
         private BoundGlobalScope _globalScope;
+        private Dictionary<BoundBlockStatement, List<Tuple<FunctionSymbol, BoundBlockStatement>>> _localFunctions = new Dictionary<BoundBlockStatement, List<Tuple<FunctionSymbol, BoundBlockStatement>>>();
 
         public Compilation(SyntaxTree coreSyntax, params SyntaxTree[] syntaxTrees) : this(null, coreSyntax, true, syntaxTrees)
         {
@@ -33,13 +34,22 @@ namespace Alto.CodeAnalysis
         public ImmutableArray<SyntaxTree> SyntaxTrees { get; set; }
         public SyntaxTree CoreSyntax { get; }
 
+        internal Dictionary<BoundBlockStatement, List<Tuple<FunctionSymbol, BoundBlockStatement>>> LocalFunctions 
+        {
+            get 
+            { 
+                return _localFunctions; 
+            } 
+        }
+
         internal BoundGlobalScope GlobalScope
         {
             get
             {
                 if (_globalScope == null)
                 {
-                    var globalScope = Binder.BindGlobalScope(Previous?.GlobalScope, CoreSyntax, SyntaxTrees, CheckCallsiteTrees);
+                    var globalScope = Binder.BindGlobalScope(Previous?.GlobalScope, CoreSyntax, SyntaxTrees, CheckCallsiteTrees, out var localFunctions);
+                    _localFunctions = localFunctions;
                     Interlocked.CompareExchange(ref _globalScope, globalScope, null);
                 }
 

--- a/src/Alto/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Alto/CodeAnalysis/DiagnosticBag.cs
@@ -74,7 +74,7 @@ namespace Alto.CodeAnalysis
 
         public void ReportSymbolAlreadyDeclared(TextLocation location, string name)
         {
-            var message = $"'{name}' is already declared in the current scope.";
+            var message = $"A symbol with name '{name}' is already declared.";
             Report(location, message);
         }
 

--- a/src/Alto/CodeAnalysis/Syntax/BlockStatementSyntax.cs
+++ b/src/Alto/CodeAnalysis/Syntax/BlockStatementSyntax.cs
@@ -4,16 +4,21 @@ namespace Alto.CodeAnalysis.Syntax
 {
     public sealed class BlockStatementSyntax : StatementSyntax
     {
-        public BlockStatementSyntax(SyntaxTree syntaxTree, SyntaxToken openBraceToken, ImmutableArray<StatementSyntax> statements, SyntaxToken closeBraceToken)
+        public BlockStatementSyntax(SyntaxTree syntaxTree, SyntaxToken openBraceToken, 
+                                    ImmutableArray<StatementSyntax> statements,
+                                    ImmutableArray<FunctionDeclarationSyntax> functions,
+                                    SyntaxToken closeBraceToken)
             : base(syntaxTree)
         {
             OpenBraceToken = openBraceToken;
             Statements = statements;
+            Functions = functions;
             CloseBraceToken = closeBraceToken;
         }
 
         public SyntaxToken OpenBraceToken { get; }
         public ImmutableArray<StatementSyntax> Statements { get; }
+        public ImmutableArray<FunctionDeclarationSyntax> Functions { get; }
         public SyntaxToken CloseBraceToken { get; }
 
         public override SyntaxKind Kind => SyntaxKind.BlockStatement;


### PR DESCRIPTION
## Syntax
```ts
{
    function evaluateProposal(👎count  : int, 👍count  : int, name : string = "test") : bool {
        if (👍count > 👎count)
        {
            print("Proposal " + name + " passed by a " + tostring(👍count) + " to " + tostring(👎count) + "margin")
            return true
        }
        print("Proposal " + name + " did not pass!")
        return false
    }

    evaluateProposal(2, 3, "Add support for nested functions?")
}
```

PS: Yes, this isn't the cleanest implementation, but hey, I'm 🥱...