### PR TITLE
Allow for referencing of custom dotnet assemblies

### DIFF
--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -2,9 +2,8 @@
     
   <Target Name="CreateManifestResourceNames" />
 
-  <Target Name="CoreCompile" DependsOnTargets="$(CoreCompileDependsOn)">
-  
-    <Exec Command="dotnet run --project &quot;$(MSBuildThisFileDirectory)\..\src\aoc\aoc.csproj&quot; -- @(Compile->'$([System.IO.Directory]::GetParent(@(Identity)))', ' ') /o &quot;@(IntermediateAssembly)&quot; @(ReferencePath->' /r &quot;%(Identity)&quot;', ' ')"
+  <Target Name="CoreCompile" DependsOnTargets="$(CoreCompileDependsOn)">  
+    <Exec Command="dotnet run --project &quot;$(MSBuildThisFileDirectory)\..\src\aoc\aoc.csproj&quot; -- @(Compile->'$([System.IO.Directory]::GetParent(@(Identity)))', ' ') /o &quot;@(IntermediateAssembly)&quot; @(ReferencePath->' /r &quot;%(Identity)&quot;', ' '), /i $([System.IO.Directory]::GetParent(@(Identity)))\packages"
           WorkingDirectory="$(MSBuildProjectDirectory)" />
 
   </Target>

--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -3,7 +3,8 @@
   <Target Name="CreateManifestResourceNames" />
 
   <Target Name="CoreCompile" DependsOnTargets="$(CoreCompileDependsOn)">  
-    <Exec Command="dotnet run --project &quot;$(MSBuildThisFileDirectory)\..\src\aoc\aoc.csproj&quot; -- @(Compile->'$([System.IO.Directory]::GetParent(@(Identity)))', ' ') /o &quot;@(IntermediateAssembly)&quot; @(ReferencePath->' /r &quot;%(Identity)&quot;', ' '), /i $([System.IO.Directory]::GetParent(@(Identity)))\packages"
+    <Message Text="Reference: @(Reference->'%(RequiredTargetFramework)')" />
+    <Exec Command="dotnet run --project &quot;$(MSBuildThisFileDirectory)\..\src\aoc\aoc.csproj&quot; -- @(Compile->'$([System.IO.Directory]::GetParent(@(Identity)))', ' ') /o &quot;@(IntermediateAssembly)&quot; @(ReferencePath->' /r &quot;%(Identity)&quot;', ' ')"
           WorkingDirectory="$(MSBuildProjectDirectory)" />
 
   </Target>

--- a/samples/test/test.ao
+++ b/samples/test/test.ao
@@ -1,0 +1,1 @@
+fileWrite("C:/Users/Filip/source/alto/samples/test/hello.txt", "Hello, Alto!")

--- a/samples/test/test.ao
+++ b/samples/test/test.ao
@@ -1,1 +1,3 @@
+print("Hello, Alto!")
+fileCreate("C:/Users/Filip/source/alto/samples/test/hello.txt")
 fileWrite("C:/Users/Filip/source/alto/samples/test/hello.txt", "Hello, Alto!")

--- a/samples/test/test.aoproj
+++ b/samples/test/test.aoproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+</Project>

--- a/samples/test/test.aoproj
+++ b/samples/test/test.aoproj
@@ -3,6 +3,13 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="ClassLibrary1">
+      <HintPath>\packages\ClassLibrary1.dll</HintPath>
+    </Reference>
+  </ItemGroup>
 
 </Project>

--- a/src/Alto/CodeAnalysis/Binding/Binder.cs
+++ b/src/Alto/CodeAnalysis/Binding/Binder.cs
@@ -900,6 +900,7 @@ namespace Alto.CodeAnalysis.Binding
                             }
                         }
                     }
+                    
                     scope = scope.Parent;
                 }
             }

--- a/src/Alto/CodeAnalysis/Binding/Binder.cs
+++ b/src/Alto/CodeAnalysis/Binding/Binder.cs
@@ -163,7 +163,7 @@ namespace Alto.CodeAnalysis.Binding
                 if (function.Declaration == null)
                 {
                     // this is an imported function
-                    functionBodies.Add(function, new BoundBlockStatement(ImmutableArray<BoundStatement>.Empty));
+                    functionBodies.Add(function, null);
                     continue;
                 }
                 
@@ -907,18 +907,19 @@ namespace Alto.CodeAnalysis.Binding
             // Imported symbol
             foreach (var import in _imports)
             {
-                Console.WriteLine($"import: {import.Assembly.Name}");
-                Console.WriteLine($"FLength: {import.Functions.Length}");
                 foreach (var method in import.Functions)
                 {
-                    Console.WriteLine($"function: {method.Name}");
+                    // also check if method is static and public
+                    
                     var function = import.TryGetFunctionSymbol(method);
-                    if (function != null)
+                    if (function != null && function.Name == name)
+                    {
                         return function;
+                    }
                 }
             }
 
-            return null;
+            return symbol;
         }
 
         private bool LocalFunctionNameIsUnique(FunctionSymbol function)

--- a/src/Alto/CodeAnalysis/Binding/BoundGlobalScope.cs
+++ b/src/Alto/CodeAnalysis/Binding/BoundGlobalScope.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using Alto.CodeAnalysis.Emit;
 using Alto.CodeAnalysis.Symbols;
 using Alto.CodeAnalysis.Syntax;
 
@@ -9,7 +10,7 @@ namespace Alto.CodeAnalysis.Binding
     {
         public BoundGlobalScope(BoundGlobalScope previous, ImmutableArray<Diagnostic> diagnostics,
             FunctionSymbol mainFunction, FunctionSymbol scriptFunction, ImmutableArray<FunctionSymbol> functions, ImmutableArray<VariableSymbol> variables, 
-            ImmutableArray<BoundStatement> statements)
+            ImmutableArray<BoundStatement> statements, ImmutableArray<AssemblyImport> imports)
         {
             Previous = previous;
             Diagnostics = diagnostics;
@@ -18,6 +19,7 @@ namespace Alto.CodeAnalysis.Binding
             Functions = functions;  
             Variables = variables;
             Statements = statements;
+            Imports = imports;
         }
 
         public BoundGlobalScope Previous { get; }
@@ -27,5 +29,6 @@ namespace Alto.CodeAnalysis.Binding
         public ImmutableArray<FunctionSymbol> Functions { get; }
         public ImmutableArray<VariableSymbol> Variables { get; }
         public ImmutableArray<BoundStatement> Statements { get; }
+        public ImmutableArray<AssemblyImport> Imports { get; }
     }
 }

--- a/src/Alto/CodeAnalysis/Binding/BoundProgram.cs
+++ b/src/Alto/CodeAnalysis/Binding/BoundProgram.cs
@@ -1,17 +1,24 @@
 using System.Collections.Immutable;
+using Alto.CodeAnalysis.Emit;
 using Alto.CodeAnalysis.Symbols;
 
 namespace Alto.CodeAnalysis.Binding
 {
     internal sealed class BoundProgram
     {
-        public BoundProgram(BoundProgram previous, DiagnosticBag diagnostics, FunctionSymbol mainFunction, FunctionSymbol scriptFunction, ImmutableDictionary<FunctionSymbol, BoundBlockStatement> functionBodies)
+        public BoundProgram(BoundProgram previous,
+                            DiagnosticBag diagnostics,
+                            FunctionSymbol mainFunction,
+                            FunctionSymbol scriptFunction,
+                            ImmutableDictionary<FunctionSymbol, BoundBlockStatement> functionBodies,
+                            ImmutableArray<AssemblyImport> imports)
         {
             Previous = previous;
             Diagnostics = diagnostics;
             MainFunction = mainFunction;
             ScriptFunction = scriptFunction;
             FunctionBodies = functionBodies;
+            Imports = imports;
         }
 
         public BoundProgram Previous { get; }
@@ -19,5 +26,6 @@ namespace Alto.CodeAnalysis.Binding
         public FunctionSymbol MainFunction { get; }
         public FunctionSymbol ScriptFunction { get; }
         public ImmutableDictionary<FunctionSymbol, BoundBlockStatement> FunctionBodies { get; internal set; }
+        public ImmutableArray<AssemblyImport> Imports { get; }
     }
 }

--- a/src/Alto/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Alto/CodeAnalysis/Binding/BoundScope.cs
@@ -35,6 +35,15 @@ namespace Alto.CodeAnalysis.Binding
 
         public Symbol TryLookupSymbol(string name)
         {
+            // DEBUG
+            // DELETE ME
+            if (_symbols != null)
+            {
+                Console.WriteLine("Symbols:");
+                foreach (var (nm, sym) in _symbols)
+                    Console.WriteLine($"    {nm}");
+            }
+            
             if (_symbols != null && _symbols.TryGetValue(name, out var symbol))
                 return symbol;
 

--- a/src/Alto/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Alto/CodeAnalysis/Binding/BoundScope.cs
@@ -35,18 +35,9 @@ namespace Alto.CodeAnalysis.Binding
 
         public Symbol TryLookupSymbol(string name)
         {
-            // DEBUG
-            // DELETE ME
-            if (_symbols != null)
-            {
-                Console.WriteLine("Symbols:");
-                foreach (var (nm, sym) in _symbols)
-                    Console.WriteLine($"    {nm}");
-            }
-            
             if (_symbols != null && _symbols.TryGetValue(name, out var symbol))
                 return symbol;
-
+            
             return Parent?.TryLookupSymbol(name);
         }
 

--- a/src/Alto/CodeAnalysis/Emit/AssemblyImport.cs
+++ b/src/Alto/CodeAnalysis/Emit/AssemblyImport.cs
@@ -112,13 +112,10 @@ namespace Alto.CodeAnalysis.Emit
             var methods = new List<MethodDefinition>();
             foreach (var module in _assembly.Modules)
             {
-                Console.WriteLine($"module: {module.Name}");
                 foreach (var type in module.Types)
                 {
-                    Console.WriteLine($"    type: {type.Name}");
                     foreach (var method in type.Methods)
                     {
-                        Console.WriteLine($"        method: {method.Name}");
                         if (method.IsConstructor || method.IsStatic || !method.IsPublic)
                             continue;
 

--- a/src/Alto/CodeAnalysis/Emit/AssemblyImport.cs
+++ b/src/Alto/CodeAnalysis/Emit/AssemblyImport.cs
@@ -11,22 +11,10 @@ namespace Alto.CodeAnalysis.Emit
     {
         private AssemblyDefinition _assembly;
         private Dictionary<FunctionSymbol, MethodDefinition> _functionSymbols = new Dictionary<FunctionSymbol, MethodDefinition>();
-        private List<MethodReference> _importedMethods;
-        private Dictionary<FunctionSymbol, MethodReference> _importedFunctionSymbols;
 
         public AssemblyImport(string path)
         {
             var assembly = AssemblyDefinition.ReadAssembly(path);
-            foreach (var module in assembly.Modules)
-            {
-                foreach (var type in module.Types)
-                {
-                    foreach (var method in type.Methods)
-                    {
-                    }
-                }
-            }
-
             _assembly = assembly;
         }
 
@@ -64,46 +52,6 @@ namespace Alto.CodeAnalysis.Emit
             return _functionSymbols.FirstOrDefault(x => x.Value == method).Key;
         }
 
-        public MethodReference GetImportedMethodReference(FunctionSymbol function) 
-            => _importedFunctionSymbols[function];
-
-        public MethodReference TryGetImportedMethodReference(FunctionSymbol function)
-        {
-            if (!_importedFunctionSymbols.ContainsKey(function))
-                return null;
-               
-            return _importedFunctionSymbols[function];
-        }
-
-        public FunctionSymbol GetImportedFunctionSymbol(MethodReference method)
-            => _importedFunctionSymbols.FirstOrDefault(x => x.Value == method).Key;
-
-        public FunctionSymbol TryGetFunctionSymbol(MethodReference method)
-        {
-            if (!_importedFunctionSymbols.ContainsValue(method))
-                return null;
-               
-            return _importedFunctionSymbols.FirstOrDefault(x => x.Value == method).Key;
-        }
-
-        public void ImportAndUpdateMethodDefinitions(AssemblyDefinition assembly)
-        {
-            var importedMethods = new List<MethodReference>();
-            var importedFunctionSymbols = new Dictionary<FunctionSymbol, MethodReference>();
-
-            foreach (var method in Functions)
-            {
-                var imported = assembly.MainModule.ImportReference(method);
-                var symbol = TryGetFunctionSymbol(method);
-
-                importedMethods.Add(imported);
-                importedFunctionSymbols.Add(symbol, imported);
-            }
-
-            _importedMethods = importedMethods;
-            _importedFunctionSymbols = importedFunctionSymbols;
-        }
-
         private ImmutableArray<MethodDefinition> GetFunctions()
         {
             // TODO: Completely revamp all of this
@@ -116,7 +64,7 @@ namespace Alto.CodeAnalysis.Emit
                 {
                     foreach (var method in type.Methods)
                     {
-                        if (method.IsConstructor || method.IsStatic || !method.IsPublic)
+                        if (method.IsConstructor || !method.IsPublic)
                             continue;
 
                         methods.Add(method);

--- a/src/Alto/CodeAnalysis/Emit/AssemblyImport.cs
+++ b/src/Alto/CodeAnalysis/Emit/AssemblyImport.cs
@@ -1,0 +1,36 @@
+using System.Collections.Immutable;
+using Mono.Cecil;
+
+namespace Alto.CodeAnalysis.Emit
+{
+    internal class AssemblyImport
+    {
+        private AssemblyDefinition _assembly;
+
+        public AssemblyImport(string path)
+        {
+            var assembly = AssemblyDefinition.ReadAssembly(path);
+            _assembly = assembly;
+        }
+
+        public AssemblyImport(AssemblyDefinition assembly)
+        {
+            _assembly = assembly;
+        }
+
+        public AssemblyDefinition Assembly => _assembly;
+        public ImmutableArray<MethodDefinition> Functions => GetFunctions();
+
+        private ImmutableArray<MethodDefinition> GetFunctions()
+        {
+            // TODO: Completely revamp all of this
+            // Once we actually have OO-Support #55
+
+            var module = _assembly.Modules.First();
+            var type = module.Types[0];
+            var functions = type.Methods;
+            
+            return functions.ToImmutableArray();
+        }
+    }
+}

--- a/src/Alto/CodeAnalysis/Emit/AssemblyImport.cs
+++ b/src/Alto/CodeAnalysis/Emit/AssemblyImport.cs
@@ -1,4 +1,8 @@
+using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
+using Alto.CodeAnalysis.Symbols;
 using Mono.Cecil;
 
 namespace Alto.CodeAnalysis.Emit
@@ -6,10 +10,23 @@ namespace Alto.CodeAnalysis.Emit
     internal class AssemblyImport
     {
         private AssemblyDefinition _assembly;
+        private Dictionary<FunctionSymbol, MethodDefinition> _functionSymbols = new Dictionary<FunctionSymbol, MethodDefinition>();
+        private List<MethodReference> _importedMethods;
+        private Dictionary<FunctionSymbol, MethodReference> _importedFunctionSymbols;
 
         public AssemblyImport(string path)
         {
             var assembly = AssemblyDefinition.ReadAssembly(path);
+            foreach (var module in assembly.Modules)
+            {
+                foreach (var type in module.Types)
+                {
+                    foreach (var method in type.Methods)
+                    {
+                    }
+                }
+            }
+
             _assembly = assembly;
         }
 
@@ -20,17 +37,97 @@ namespace Alto.CodeAnalysis.Emit
 
         public AssemblyDefinition Assembly => _assembly;
         public ImmutableArray<MethodDefinition> Functions => GetFunctions();
+        public Dictionary<FunctionSymbol, MethodDefinition> FunctionSymbols => _functionSymbols;
+
+        public void AddFunctionSymbol(FunctionSymbol function, MethodDefinition method)
+            => _functionSymbols.Add(function, method);
+
+        public MethodDefinition GetMethodDefinition(FunctionSymbol function) 
+            => _functionSymbols[function];
+
+        public MethodDefinition TryGetMethodDefinition(FunctionSymbol function)
+        {
+            if (!_functionSymbols.ContainsKey(function))
+                return null;
+               
+            return _functionSymbols[function];
+        }
+
+        public FunctionSymbol GetFunctionSymbol(MethodDefinition method)
+            => _functionSymbols.FirstOrDefault(x => x.Value == method).Key;
+
+        public FunctionSymbol TryGetFunctionSymbol(MethodDefinition method)
+        {
+            if (!_functionSymbols.ContainsValue(method))
+                return null;
+               
+            return _functionSymbols.FirstOrDefault(x => x.Value == method).Key;
+        }
+
+        public MethodReference GetImportedMethodReference(FunctionSymbol function) 
+            => _importedFunctionSymbols[function];
+
+        public MethodReference TryGetImportedMethodReference(FunctionSymbol function)
+        {
+            if (!_importedFunctionSymbols.ContainsKey(function))
+                return null;
+               
+            return _importedFunctionSymbols[function];
+        }
+
+        public FunctionSymbol GetImportedFunctionSymbol(MethodReference method)
+            => _importedFunctionSymbols.FirstOrDefault(x => x.Value == method).Key;
+
+        public FunctionSymbol TryGetFunctionSymbol(MethodReference method)
+        {
+            if (!_importedFunctionSymbols.ContainsValue(method))
+                return null;
+               
+            return _importedFunctionSymbols.FirstOrDefault(x => x.Value == method).Key;
+        }
+
+        public void ImportAndUpdateMethodDefinitions(AssemblyDefinition assembly)
+        {
+            var importedMethods = new List<MethodReference>();
+            var importedFunctionSymbols = new Dictionary<FunctionSymbol, MethodReference>();
+
+            foreach (var method in Functions)
+            {
+                var imported = assembly.MainModule.ImportReference(method);
+                var symbol = TryGetFunctionSymbol(method);
+
+                importedMethods.Add(imported);
+                importedFunctionSymbols.Add(symbol, imported);
+            }
+
+            _importedMethods = importedMethods;
+            _importedFunctionSymbols = importedFunctionSymbols;
+        }
 
         private ImmutableArray<MethodDefinition> GetFunctions()
         {
             // TODO: Completely revamp all of this
             // Once we actually have OO-Support #55
 
-            var module = _assembly.Modules.First();
-            var type = module.Types[0];
-            var functions = type.Methods;
+            var methods = new List<MethodDefinition>();
+            foreach (var module in _assembly.Modules)
+            {
+                Console.WriteLine($"module: {module.Name}");
+                foreach (var type in module.Types)
+                {
+                    Console.WriteLine($"    type: {type.Name}");
+                    foreach (var method in type.Methods)
+                    {
+                        Console.WriteLine($"        method: {method.Name}");
+                        if (method.IsConstructor || method.IsStatic || !method.IsPublic)
+                            continue;
+
+                        methods.Add(method);
+                    }
+                }
+            }
             
-            return functions.ToImmutableArray();
+            return methods.ToImmutableArray();
         }
     }
 }

--- a/src/Alto/CodeAnalysis/Emit/Emitter.cs
+++ b/src/Alto/CodeAnalysis/Emit/Emitter.cs
@@ -11,7 +11,7 @@ using Mono.Cecil.Rocks;
 namespace Alto.CodeAnalysis.Emit
 {
     // Suppresses the warning about nullable reference types
-    #pragma warning disable CS8632 
+#pragma warning disable CS8632
 
     internal sealed class Emitter
     {
@@ -156,7 +156,7 @@ namespace Alto.CodeAnalysis.Emit
             _randomCtorReference = ResolveMethod("System.Random", ".ctor", Array.Empty<string>());
             _randomNextReference = ResolveMethod("System.Random", "Next", new [] {"System.Int32", "System.Int32"});
         }
-        
+
         internal static ImmutableArray<Diagnostic> Emit(BoundProgram program, string moduleName, string[]   references, string outPath)
         {
             var emitter = new Emitter(moduleName, references);
@@ -598,6 +598,25 @@ namespace Alto.CodeAnalysis.Emit
             ilProcessor.Emit(OpCodes.Newobj, _randomCtorReference);
             ilProcessor.Emit(OpCodes.Stsfld, _randomFieldDefinition);
             ilProcessor.Emit(OpCodes.Ret);
+        }
+
+        internal static TypeSymbol GetTypeSymbol(TypeReference declaringType)
+        {
+            switch (declaringType.FullName)
+            {
+                case "System.String":
+                    return TypeSymbol.String;
+                case "System.Int32":
+                    return TypeSymbol.Int;
+                case "System.Boolean":
+                    return TypeSymbol.Bool;
+                case "System.Object":
+                    return TypeSymbol.Any;
+                case "System.Void":
+                    return TypeSymbol.Void;
+                default:
+                    throw new Exception($"Can't translate C# type '{declaringType.FullName}' to Alto type.");
+            }
         }
     }
 }

--- a/src/Alto/CodeAnalysis/Emit/Emitter.cs
+++ b/src/Alto/CodeAnalysis/Emit/Emitter.cs
@@ -44,7 +44,6 @@ namespace Alto.CodeAnalysis.Emit
             {
                 try
                 {
-                    Console.WriteLine($"reading reference: {reference}");
                     var refAssembly = AssemblyDefinition.ReadAssembly(reference);
                     assemblies.Add(refAssembly);
                 }
@@ -181,6 +180,10 @@ namespace Alto.CodeAnalysis.Emit
 
             foreach (var (function, body) in program.FunctionBodies)
             {
+                // imported function
+                if (body == null)
+                    continue;
+                
                 EmitFunctionDeclaration(function);
                 EmitFunctionBody(function, body);
             }
@@ -221,7 +224,7 @@ namespace Alto.CodeAnalysis.Emit
         }
 
         private void EmitFunctionBody(FunctionSymbol function, BoundBlockStatement body)
-        {
+        {   
             var method = _methods[function];
             _locals.Clear();
             _fixups.Clear();

--- a/src/aoc/Program.cs
+++ b/src/aoc/Program.cs
@@ -63,10 +63,6 @@ namespace Alto
 
             references = newReferences;
 
-            Console.WriteLine($"rl: {references.Count}");
-            foreach (var r in references)
-                Console.WriteLine($"reference: {r}");
-
             if (helpRequested)
             {
                 options.WriteOptionDescriptions(Console.Out);

--- a/src/aoc/Program.cs
+++ b/src/aoc/Program.cs
@@ -12,7 +12,7 @@ namespace Alto
 {
     internal static class Program
     {
-        private static string[] _requiredAssemblies = new string[] {"System.Runtime", "System.Console", "System.Runtime.Extensions"};
+        private static string[] _requiredAssemblies = new string[] {"System.Runtime.dll", "System.Console.dll", "System.Runtime.Extensions.dll"};
 
         private static int Main(string[] args) 
         {
@@ -25,6 +25,7 @@ namespace Alto
             List<string> references = new List<string>();
             string outputPath = null;
             string moduleName = null;
+            string dependenciesPath = null;
             string projectDirectoryPath = args[0];
             bool helpRequested = false;
 
@@ -34,17 +35,37 @@ namespace Alto
                 { "r=", "The {path} of an assembly to reference", r => references.Add(r) },
                 { "o=", "The output {path} of the assembly to create", o => outputPath = o },
                 { "m=", "The {name} of the module", m => moduleName = m },
+                { "i=", "Dependencies folder path", i => dependenciesPath = i},
                 { "help|h|?", "Help!!!", h => helpRequested = true }
             };
-
-            // trim references
-            var referencesToRemove = references.Where(r => r.Contains("System.") && !_requiredAssemblies.Contains(r));
-            foreach (var reference in referencesToRemove)
-                references.Remove(reference);
 
             var argsToParse = args.ToList();
             argsToParse.RemoveAt(0);    
             options.Parse(argsToParse.ToArray());
+
+            // trim references
+            var newReferences = new List<string>();
+            foreach (var reference in references)
+            {
+                bool found = false;
+                foreach (var required in _requiredAssemblies)
+                {
+                    if (reference.Contains(required))
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (found)
+                    newReferences.Add(reference);
+            }
+
+            references = newReferences;
+
+            Console.WriteLine($"rl: {references.Count}");
+            foreach (var r in references)
+                Console.WriteLine($"reference: {r}");
 
             if (helpRequested)
             {
@@ -85,8 +106,18 @@ namespace Alto
 
             if (hasErrors)
                 return 1;
+
+            var dependencies = new List<string>();
+            foreach (var file in Directory.GetFiles(dependenciesPath))
+            {
+                var info = new FileInfo(file);
+                if (info.Extension != ".dll")
+                    continue;
+
+                dependencies.Add(file);
+            }
             
-            var compilation = Compilation.Create(syntaxTrees.ToArray());
+            var compilation = Compilation.Create(dependencies, syntaxTrees.ToArray());
             var diagnostics = compilation.Emit(moduleName, references.ToArray(), outputPath);
             if (diagnostics.Any())
             {
@@ -105,7 +136,7 @@ namespace Alto
                 foreach (var file in Directory.EnumerateFiles(path, "*.ao", SearchOption.AllDirectories))
                     if (file != path)
                         result.Add(file);
-        
+
             return result;
         }
     }

--- a/src/aoi/AltoRepl.cs
+++ b/src/aoi/AltoRepl.cs
@@ -35,7 +35,9 @@ namespace Alto
 
             Console.Title = text;
             var syntaxTree = SyntaxTree.Parse(text);
-            Compilation compilation = Compilation.CreateScript(_previous, syntaxTree);
+
+            var dependencies = new List<string>();
+            Compilation compilation = Compilation.CreateScript(dependencies, _previous, syntaxTree);
 
             if (_showTree)
             {
@@ -250,7 +252,8 @@ namespace Alto
             EvaluateSubmission(txt);
 
             var tree = SyntaxTree.Load(path);
-            _previous = Compilation.CreateScript(_previous, tree);
+            var dependencies = new List<string>();
+            _previous = Compilation.CreateScript(dependencies, _previous, tree);
         }
 
         [MetaCommand("ls", description: "Lists all symbols.")]


### PR DESCRIPTION
This essentially allows us to call `public` and `static` methods from all types in our non-system references. This will be changed later on to go hand-in-hand with our OO structure. As of now, we just "merge" the referenced methods with our locally declared functions.

Contributes to #80